### PR TITLE
Spinner cleanup, renderer migration, 90% coverage

### DIFF
--- a/clickup/cli/commands/bulk.py
+++ b/clickup/cli/commands/bulk.py
@@ -11,14 +11,7 @@ from rich.table import Table
 
 from ...core import ClickUpClient, ClickUpError, Config
 from ..output import render_error
-from ..utils import (
-    BarColumn,
-    Progress,
-    SpinnerColumn,
-    TaskProgressColumn,
-    TextColumn,
-    run_async,
-)
+from ..utils import run_async
 
 app = typer.Typer(help="Bulk operations and import/export")
 console = Console()
@@ -56,83 +49,70 @@ def export_tasks(
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    BarColumn(),
-                    TaskProgressColumn(),
-                    console=console,
-                ) as progress:
-                    task_id = progress.add_task("Fetching tasks...", total=None)
+                filters = {}
+                if not include_completed:
+                    filters["include_closed"] = False
 
-                    filters = {}
-                    if not include_completed:
-                        filters["include_closed"] = False
+                tasks = await client.get_tasks(list_id_to_use, **filters)
 
-                    tasks = await client.get_tasks(list_id_to_use, **filters)
-                    progress.update(task_id, description=f"Exporting {len(tasks)} tasks...")
+                if format.lower() == "csv":
+                    # Export to CSV
+                    with open(output_file, "w", newline="", encoding="utf-8") as csvfile:
+                        fieldnames = [
+                            "id",
+                            "name",
+                            "description",
+                            "status",
+                            "priority",
+                            "assignees",
+                            "due_date",
+                            "date_created",
+                            "date_updated",
+                            "url",
+                        ]
+                        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+                        writer.writeheader()
 
-                    if format.lower() == "csv":
-                        # Export to CSV
-                        with open(output_file, "w", newline="", encoding="utf-8") as csvfile:
-                            fieldnames = [
-                                "id",
-                                "name",
-                                "description",
-                                "status",
-                                "priority",
-                                "assignees",
-                                "due_date",
-                                "date_created",
-                                "date_updated",
-                                "url",
-                            ]
-                            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-                            writer.writeheader()
-
-                            for task in tasks:
-                                status = task.status.status if task.status else ""
-                                priority = task.priority.priority or "" if task.priority else ""
-                                assignees = ", ".join([a.username for a in task.assignees]) if task.assignees else ""
-
-                                writer.writerow(
-                                    {
-                                        "id": task.id,
-                                        "name": task.name,
-                                        "description": task.description or "",
-                                        "status": status,
-                                        "priority": priority,
-                                        "assignees": assignees,
-                                        "due_date": task.due_date or "",
-                                        "date_created": task.date_created or "",
-                                        "date_updated": task.date_updated or "",
-                                        "url": task.url or "",
-                                    }
-                                )
-
-                    elif format.lower() == "json":
-                        # Export to JSON
-                        task_data = []
                         for task in tasks:
-                            task_dict = task.model_dump()
-                            # Simplify complex fields for JSON export
-                            if task_dict.get("status"):
-                                task_dict["status"] = task_dict["status"].get("status", "")
-                            if task_dict.get("priority"):
-                                task_dict["priority"] = task_dict["priority"].get("priority", "")
-                            if task_dict.get("assignees"):
-                                task_dict["assignees"] = [a.get("username", "") for a in task_dict["assignees"]]
-                            task_data.append(task_dict)
+                            status = task.status.status if task.status else ""
+                            priority = task.priority.priority or "" if task.priority else ""
+                            assignees = ", ".join([a.username for a in task.assignees]) if task.assignees else ""
 
-                        with open(output_file, "w", encoding="utf-8") as jsonfile:
-                            json.dump(task_data, jsonfile, indent=2, ensure_ascii=False)
+                            writer.writerow(
+                                {
+                                    "id": task.id,
+                                    "name": task.name,
+                                    "description": task.description or "",
+                                    "status": status,
+                                    "priority": priority,
+                                    "assignees": assignees,
+                                    "due_date": task.due_date or "",
+                                    "date_created": task.date_created or "",
+                                    "date_updated": task.date_updated or "",
+                                    "url": task.url or "",
+                                }
+                            )
 
-                    else:
-                        render_error(f"Unsupported format: {format}")
-                        raise typer.Exit(1) from None
+                elif format.lower() == "json":
+                    # Export to JSON
+                    task_data = []
+                    for task in tasks:
+                        task_dict = task.model_dump()
+                        # Simplify complex fields for JSON export
+                        if task_dict.get("status"):
+                            task_dict["status"] = task_dict["status"].get("status", "")
+                        if task_dict.get("priority"):
+                            task_dict["priority"] = task_dict["priority"].get("priority", "")
+                        if task_dict.get("assignees"):
+                            task_dict["assignees"] = [a.get("username", "") for a in task_dict["assignees"]]
+                        task_data.append(task_dict)
 
-                    progress.update(task_id, description="✅ Export completed", completed=True)
+                    with open(output_file, "w", encoding="utf-8") as jsonfile:
+                        json.dump(task_data, jsonfile, indent=2, ensure_ascii=False)
 
+                else:
+                    render_error(f"Unsupported format: {format}")
+                    raise typer.Exit(1) from None
                 console.print(f"✅ Exported {len(tasks)} tasks to {output_file}")
 
         except ClickUpError as e:
@@ -229,50 +209,37 @@ def import_tasks(
                 raise typer.Exit(2)
 
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    BarColumn(),
-                    TaskProgressColumn(),
-                    console=console,
-                ) as progress:
-                    import_task = progress.add_task("Importing tasks...", total=len(tasks_data))
+                created_count = 0
+                failed_count = 0
 
-                    created_count = 0
-                    failed_count = 0
+                # Process in batches
+                for i in range(0, len(tasks_data), batch_size):
+                    batch = tasks_data[i : i + batch_size]
 
-                    # Process in batches
-                    for i in range(0, len(tasks_data), batch_size):
-                        batch = tasks_data[i : i + batch_size]
+                    for task_data in batch:
+                        try:
+                            # Prepare task creation data
+                            create_data: dict[str, Any] = {"name": task_data.get("name", "Untitled Task")}
 
-                        for task_data in batch:
-                            try:
-                                # Prepare task creation data
-                                create_data: dict[str, Any] = {"name": task_data.get("name", "Untitled Task")}
+                            if task_data.get("description"):
+                                create_data["description"] = task_data["description"]
+                            if task_data.get("priority"):
+                                try:
+                                    create_data["priority"] = int(task_data["priority"])
+                                except (ValueError, TypeError):
+                                    pass
+                            if task_data.get("due_date"):
+                                create_data["due_date"] = task_data["due_date"]
 
-                                if task_data.get("description"):
-                                    create_data["description"] = task_data["description"]
-                                if task_data.get("priority"):
-                                    try:
-                                        create_data["priority"] = int(task_data["priority"])
-                                    except (ValueError, TypeError):
-                                        pass
-                                if task_data.get("due_date"):
-                                    create_data["due_date"] = task_data["due_date"]
+                            # Create task
+                            await client.create_task(list_id_to_use, **create_data)
+                            created_count += 1
 
-                                # Create task
-                                await client.create_task(list_id_to_use, **create_data)
-                                created_count += 1
-
-                            except Exception as e:
-                                console.print(
-                                    f"[yellow]Failed to create task '{task_data.get('name', 'Unknown')}': {e}[/yellow]"
-                                )
-                                failed_count += 1
-
-                            progress.advance(import_task)
-
-                    progress.update(import_task, description="✅ Import completed")
+                        except Exception as e:
+                            console.print(
+                                f"[yellow]Failed to create task '{task_data.get('name', 'Unknown')}': {e}[/yellow]"
+                            )
+                            failed_count += 1
 
                 console.print(f"✅ Import completed: {created_count} created, {failed_count} failed")
 
@@ -322,84 +289,69 @@ def bulk_update(
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    BarColumn(),
-                    TaskProgressColumn(),
-                    console=console,
-                ) as progress:
-                    fetch_task = progress.add_task("Fetching tasks...", total=None)
+                filters = {}
+                if filter_status:
+                    filters["statuses"] = [filter_status]
 
-                    filters = {}
-                    if filter_status:
-                        filters["statuses"] = [filter_status]
+                tasks = await client.get_tasks(list_id_to_use, **filters)
 
-                    tasks = await client.get_tasks(list_id_to_use, **filters)
-                    progress.update(fetch_task, description=f"Found {len(tasks)} tasks")
+                if not tasks:
+                    console.print("[yellow]No tasks found matching criteria.[/yellow]")
+                    return
 
-                    if not tasks:
-                        console.print("[yellow]No tasks found matching criteria.[/yellow]")
-                        return
+                # Preview changes
+                table = Table(title="Bulk Update Preview", show_header=True)
+                table.add_column("Task", style="bold")
+                table.add_column("Current Status", style="blue")
+                table.add_column("New Status", style="green")
+                table.add_column("Current Priority", style="yellow")
+                table.add_column("New Priority", style="yellow")
 
-                    # Preview changes
-                    table = Table(title="Bulk Update Preview", show_header=True)
-                    table.add_column("Task", style="bold")
-                    table.add_column("Current Status", style="blue")
-                    table.add_column("New Status", style="green")
-                    table.add_column("Current Priority", style="yellow")
-                    table.add_column("New Priority", style="yellow")
+                updates: dict[str, Any] = {}
+                if new_status:
+                    updates["status"] = new_status
+                if new_priority:
+                    updates["priority"] = new_priority
+                if new_assignee:
+                    updates["assignees"] = [new_assignee]
 
-                    updates: dict[str, Any] = {}
-                    if new_status:
-                        updates["status"] = new_status
-                    if new_priority:
-                        updates["priority"] = new_priority
-                    if new_assignee:
-                        updates["assignees"] = [new_assignee]
+                for task in tasks[:10]:  # Show first 10
+                    current_status = task.status.get("status", "Unknown") if task.status else "Unknown"
+                    current_priority = task.priority.get("priority", "None") if task.priority else "None"
 
-                    for task in tasks[:10]:  # Show first 10
-                        current_status = task.status.get("status", "Unknown") if task.status else "Unknown"
-                        current_priority = task.priority.get("priority", "None") if task.priority else "None"
+                    table.add_row(
+                        task.name[:30] + "..." if len(task.name) > 30 else task.name,
+                        current_status,
+                        new_status or current_status,
+                        current_priority,
+                        str(new_priority) if new_priority else current_priority,
+                    )
 
-                        table.add_row(
-                            task.name[:30] + "..." if len(task.name) > 30 else task.name,
-                            current_status,
-                            new_status or current_status,
-                            current_priority,
-                            str(new_priority) if new_priority else current_priority,
-                        )
+                console.print(table)
+                if len(tasks) > 10:
+                    console.print(f"... and {len(tasks) - 10} more tasks")
 
-                    console.print(table)
-                    if len(tasks) > 10:
-                        console.print(f"... and {len(tasks) - 10} more tasks")
+                if dry_run:
+                    console.print("[yellow]This was a dry run. Remove --dry-run to apply changes.[/yellow]")
+                    return
 
-                    if dry_run:
-                        console.print("[yellow]This was a dry run. Remove --dry-run to apply changes.[/yellow]")
-                        return
+                if not force:
+                    render_error(
+                        f"Refusing to update {len(tasks)} tasks without --force/--yes (use --dry-run to preview)."
+                    )
+                    raise typer.Exit(2)
 
-                    if not force:
-                        render_error(
-                            f"Refusing to update {len(tasks)} tasks without --force/--yes (use --dry-run to preview)."
-                        )
-                        raise typer.Exit(2)
+                # Apply updates
+                updated_count = 0
+                failed_count = 0
 
-                    # Apply updates
-                    update_task = progress.add_task("Updating tasks...", total=len(tasks))
-                    updated_count = 0
-                    failed_count = 0
-
-                    for task in tasks:
-                        try:
-                            await client.update_task(task.id, **updates)
-                            updated_count += 1
-                        except Exception as e:
-                            console.print(f"[yellow]Failed to update task '{task.name}': {e}[/yellow]")
-                            failed_count += 1
-
-                        progress.advance(update_task)
-
-                    progress.update(update_task, description="✅ Bulk update completed")
+                for task in tasks:
+                    try:
+                        await client.update_task(task.id, **updates)
+                        updated_count += 1
+                    except Exception as e:
+                        console.print(f"[yellow]Failed to update task '{task.name}': {e}[/yellow]")
+                        failed_count += 1
 
                 console.print(f"✅ Bulk update completed: {updated_count} updated, {failed_count} failed")
 

--- a/clickup/cli/commands/discover.py
+++ b/clickup/cli/commands/discover.py
@@ -3,11 +3,10 @@
 import typer
 from rich.console import Console
 from rich.table import Table
-from rich.tree import Tree
 
 from ...core import ClickUpClient, ClickUpError, Config
-from ..output import render_error
-from ..utils import Progress, SpinnerColumn, TextColumn, run_async
+from ..output import render_error, render_hierarchy
+from ..utils import run_async
 
 app = typer.Typer(help="Discover and navigate ClickUp hierarchy")
 console = Console()
@@ -17,11 +16,11 @@ async def get_client() -> ClickUpClient:
     """Get configured ClickUp client."""
     config = Config()
     if not config.has_credentials():
-        console.print(
-            "[red]Error: No ClickUp API token configured. Set CLICKUP_API_KEY in your "
-            "environment (or .env), or run 'clickup config set-token <token>'.[/red]"
+        render_error(
+            "No ClickUp API token configured. "
+            "Set CLICKUP_API_KEY in your environment (or .env), or run 'clickup config set-token <token>'."
         )
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     return ClickUpClient(config, console)
 
 
@@ -38,76 +37,53 @@ def show_hierarchy(
     async def _show_hierarchy() -> None:
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Building hierarchy...", total=None)
+                id_to_use = workspace_id or team_id
+                workspaces = [await client.get_team(id_to_use)] if id_to_use else await client.get_teams()
 
-                    tree = Tree("🏢 ClickUp Hierarchy")
-
-                    # Use either workspace_id or team_id (they're the same thing)
-                    id_to_use = workspace_id or team_id
-
-                    if id_to_use:
-                        workspaces = [await client.get_team(id_to_use)]
-                    else:
-                        workspaces = await client.get_teams()
-
-                    for workspace in workspaces:
-                        workspace_node = tree.add(
-                            f"🏢 [bold cyan]{workspace.name}[/bold cyan] ([dim]{workspace.id}[/dim])"
-                        )
-
-                        if max_depth >= 2:
-                            try:
-                                spaces = await client.get_spaces(workspace.id)
-                                for space in spaces:
-                                    space_node = workspace_node.add(
-                                        f"📁 [blue]{space.name}[/blue] ([dim]{space.id}[/dim])"
-                                    )
-
-                                    if max_depth >= 3:
-                                        # Get folders in space
+                data: dict = {"workspaces": []}
+                for workspace in workspaces:
+                    ws_dict: dict = {"id": workspace.id, "name": workspace.name, "spaces": []}
+                    if max_depth >= 2:
+                        try:
+                            spaces = await client.get_spaces(workspace.id)
+                        except ClickUpError:
+                            spaces = []
+                        for space in spaces:
+                            sp_dict: dict = {
+                                "id": space.id,
+                                "name": space.name,
+                                "folders": [],
+                                "folderless_lists": [],
+                            }
+                            if max_depth >= 3:
+                                try:
+                                    folders = await client.get_folders(space.id)
+                                except ClickUpError:
+                                    folders = []
+                                for folder in folders:
+                                    f_dict: dict = {"id": folder.id, "name": folder.name, "lists": []}
+                                    if max_depth >= 4:
                                         try:
-                                            folders = await client.get_folders(space.id)
-                                            for folder in folders:
-                                                folder_node = space_node.add(
-                                                    f"📂 [yellow]{folder.name}[/yellow] ([dim]{folder.id}[/dim])"
-                                                )
-
-                                                if max_depth >= 4:
-                                                    # Get lists in folder
-                                                    try:
-                                                        lists = await client.get_lists(folder.id)
-                                                        for lst in lists:
-                                                            folder_node.add(
-                                                                f"📋 [green]{lst.name}[/green] ([dim]{lst.id}[/dim]) - "
-                                                                f"{lst.task_count} tasks"
-                                                            )
-                                                    except ClickUpError:
-                                                        pass
+                                            lists = await client.get_lists(folder.id)
+                                            f_dict["lists"] = [
+                                                {"id": lst.id, "name": lst.name, "task_count": lst.task_count}
+                                                for lst in lists
+                                            ]
                                         except ClickUpError:
                                             pass
+                                    sp_dict["folders"].append(f_dict)
+                                try:
+                                    folderless = await client.get_folderless_lists(space.id)
+                                    sp_dict["folderless_lists"] = [
+                                        {"id": lst.id, "name": lst.name, "task_count": lst.task_count}
+                                        for lst in folderless
+                                    ]
+                                except ClickUpError:
+                                    pass
+                            ws_dict["spaces"].append(sp_dict)
+                    data["workspaces"].append(ws_dict)
 
-                                        # Get folderless lists in space
-                                        try:
-                                            folderless_lists = await client.get_folderless_lists(space.id)
-                                            if folderless_lists:
-                                                folderless_node = space_node.add("📂 [yellow]Folderless Lists[/yellow]")
-                                                for lst in folderless_lists:
-                                                    folderless_node.add(
-                                                        f"📋 [green]{lst.name}[/green] ([dim]{lst.id}[/dim]) - "
-                                                        f"{lst.task_count} tasks"
-                                                    )
-                                        except ClickUpError:
-                                            pass
-                            except ClickUpError as e:
-                                workspace_node.add(f"❌ [red]Error loading spaces: {e}[/red]")
-
-                    console.print(tree)
-
+                render_hierarchy(data)
         except ClickUpError as e:
             render_error(f"ClickUp API Error: {e}")
             raise typer.Exit(1) from e
@@ -221,80 +197,72 @@ def find_path(list_id: str = typer.Argument(..., help="List ID to find path for"
     async def _find_path() -> None:
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Finding path...", total=None)
+                # Get list details
+                lst = await client.get_list(list_id)
 
-                    # Get list details
-                    lst = await client.get_list(list_id)
+                # Build path by working backwards
+                path_parts = []
+                path_parts.append(f"📋 [green]{lst.name}[/green] ([dim]{lst.id}[/dim])")
 
-                    # Build path by working backwards
-                    path_parts = []
-                    path_parts.append(f"📋 [green]{lst.name}[/green] ([dim]{lst.id}[/dim])")
+                # Find which folder/space contains this list
+                workspaces = await client.get_teams()
+                found_path = False
 
-                    # Find which folder/space contains this list
-                    workspaces = await client.get_teams()
-                    found_path = False
-
-                    for workspace in workspaces:
-                        if found_path:
-                            break
-
-                        try:
-                            spaces = await client.get_spaces(workspace.id)
-                            for space in spaces:
-                                if found_path:
-                                    break
-
-                                # Check folderless lists first
-                                try:
-                                    folderless_lists = await client.get_folderless_lists(space.id)
-                                    if any(lst.id == list_id for lst in folderless_lists):
-                                        path_parts.insert(0, f"📁 [blue]{space.name}[/blue] ([dim]{space.id}[/dim])")
-                                        path_parts.insert(
-                                            0, f"🏢 [cyan]{workspace.name}[/cyan] ([dim]{workspace.id}[/dim])"
-                                        )
-                                        found_path = True
-                                        break
-                                except ClickUpError:
-                                    pass
-
-                                # Check folders
-                                try:
-                                    folders = await client.get_folders(space.id)
-                                    for folder in folders:
-                                        try:
-                                            lists = await client.get_lists(folder.id)
-                                            if any(lst.id == list_id for lst in lists):
-                                                path_parts.insert(
-                                                    0, f"📂 [yellow]{folder.name}[/yellow] ([dim]{folder.id}[/dim])"
-                                                )
-                                                path_parts.insert(
-                                                    0, f"📁 [blue]{space.name}[/blue] ([dim]{space.id}[/dim])"
-                                                )
-                                                path_parts.insert(
-                                                    0, f"🏢 [cyan]{workspace.name}[/cyan] ([dim]{workspace.id}[/dim])"
-                                                )
-                                                found_path = True
-                                                break
-                                        except ClickUpError:
-                                            pass
-                                except ClickUpError:
-                                    pass
-                        except ClickUpError:
-                            pass
-
+                for workspace in workspaces:
                     if found_path:
-                        console.print("\n📍 [bold]Path to List:[/bold]")
-                        for i, part in enumerate(path_parts):
-                            indent = "  " * i
-                            console.print(f"{indent}{part}")
-                    else:
-                        console.print(f"[yellow]Could not find path for list {list_id}[/yellow]")
+                        break
 
+                    try:
+                        spaces = await client.get_spaces(workspace.id)
+                        for space in spaces:
+                            if found_path:
+                                break
+
+                            # Check folderless lists first
+                            try:
+                                folderless_lists = await client.get_folderless_lists(space.id)
+                                if any(lst.id == list_id for lst in folderless_lists):
+                                    path_parts.insert(0, f"📁 [blue]{space.name}[/blue] ([dim]{space.id}[/dim])")
+                                    path_parts.insert(
+                                        0, f"🏢 [cyan]{workspace.name}[/cyan] ([dim]{workspace.id}[/dim])"
+                                    )
+                                    found_path = True
+                                    break
+                            except ClickUpError:
+                                pass
+
+                            # Check folders
+                            try:
+                                folders = await client.get_folders(space.id)
+                                for folder in folders:
+                                    try:
+                                        lists = await client.get_lists(folder.id)
+                                        if any(lst.id == list_id for lst in lists):
+                                            path_parts.insert(
+                                                0, f"📂 [yellow]{folder.name}[/yellow] ([dim]{folder.id}[/dim])"
+                                            )
+                                            path_parts.insert(
+                                                0, f"📁 [blue]{space.name}[/blue] ([dim]{space.id}[/dim])"
+                                            )
+                                            path_parts.insert(
+                                                0, f"🏢 [cyan]{workspace.name}[/cyan] ([dim]{workspace.id}[/dim])"
+                                            )
+                                            found_path = True
+                                            break
+                                    except ClickUpError:
+                                        pass
+                            except ClickUpError:
+                                pass
+                    except ClickUpError:
+                        pass
+
+                if found_path:
+                    console.print("\n📍 [bold]Path to List:[/bold]")
+                    for i, part in enumerate(path_parts):
+                        indent = "  " * i
+                        console.print(f"{indent}{part}")
+                else:
+                    console.print(f"[yellow]Could not find path for list {list_id}[/yellow]")
         except ClickUpError as e:
             render_error(f"ClickUp API Error: {e}")
             raise typer.Exit(1) from e

--- a/clickup/cli/commands/list.py
+++ b/clickup/cli/commands/list.py
@@ -8,7 +8,7 @@ from rich.table import Table
 
 from ...core import ClickUpClient, ClickUpError, Config
 from ..output import render_error
-from ..utils import Progress, SpinnerColumn, TextColumn, run_async
+from ..utils import run_async
 
 app = typer.Typer(help="List management")
 console = Console()
@@ -41,19 +41,12 @@ def list_lists(
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Fetching lists...", total=None)
-                    if folder_id:
-                        lists = await client.get_lists(folder_id)
-                    else:
-                        # space_id is guaranteed non-None here due to the check above
-                        assert space_id is not None
-                        lists = await client.get_folderless_lists(space_id)
-
+                if folder_id:
+                    lists = await client.get_lists(folder_id)
+                else:
+                    # space_id is guaranteed non-None here due to the check above
+                    assert space_id is not None
+                    lists = await client.get_folderless_lists(space_id)
                 if not lists:
                     console.print("[yellow]No lists found.[/yellow]")
                     return
@@ -98,14 +91,7 @@ def get_list(list_id: str | None = typer.Option(None, "--list-id", "-l", help="L
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Fetching list...", total=None)
-                    list_item = await client.get_list(list_id_to_use)
-
+                list_item = await client.get_list(list_id_to_use)
                 # Create detailed list info table
                 table = Table(title=f"List: {list_item.name}", show_header=False)
                 table.add_column("Field", style="cyan", width=15)
@@ -169,19 +155,12 @@ def create_list(
                 list_data["assignee"] = assignee
 
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Creating list...", total=None)
-                    if folder_id:
-                        list_item = await client.create_list(folder_id, **list_data)
-                    else:
-                        # space_id is guaranteed non-None here due to the check above
-                        assert space_id is not None
-                        list_item = await client.create_folderless_list(space_id, **list_data)
-
+                if folder_id:
+                    list_item = await client.create_list(folder_id, **list_data)
+                else:
+                    # space_id is guaranteed non-None here due to the check above
+                    assert space_id is not None
+                    list_item = await client.create_folderless_list(space_id, **list_data)
                 console.print(f"✅ Created list: {list_item.name} (ID: {list_item.id})")
 
         except ClickUpError as e:

--- a/clickup/cli/commands/task.py
+++ b/clickup/cli/commands/task.py
@@ -7,7 +7,7 @@ from rich.console import Console
 
 from ...core import ClickUpClient, ClickUpError, Config
 from ..output import render_comments, render_error, render_message, render_task, render_tasks
-from ..utils import Progress, SpinnerColumn, TextColumn, run_async
+from ..utils import run_async
 
 app = typer.Typer(help="Task management")
 console = Console()
@@ -84,25 +84,17 @@ def list_tasks(
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Fetching tasks...", total=None)
+                filters: dict[str, Any] = {}
+                if status:
+                    filters["statuses"] = [status]
+                if assignee:
+                    filters["assignees"] = [assignee]
+                if sort:
+                    filters["order_by"] = sort
+                if reverse:
+                    filters["reverse"] = "true"
 
-                    filters: dict[str, Any] = {}
-                    if status:
-                        filters["statuses"] = [status]
-                    if assignee:
-                        filters["assignees"] = [assignee]
-                    if sort:
-                        filters["order_by"] = sort
-                    if reverse:
-                        filters["reverse"] = "true"
-
-                    tasks = await client.get_tasks(list_id_to_use, **filters)
-
+                tasks = await client.get_tasks(list_id_to_use, **filters)
                 if not tasks:
                     render_message("No tasks found.", "warn")
                     return
@@ -129,14 +121,7 @@ def get_task(task_id: str = typer.Argument(..., help="Task ID")) -> None:
     async def _get_task() -> None:
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Fetching task...", total=None)
-                    task = await client.get_task(task_id)
-
+                task = await client.get_task(task_id)
                 render_task(task)
 
         except ClickUpError as e:
@@ -165,25 +150,17 @@ def my_tasks(
     async def _my_tasks() -> None:
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Fetching your tasks...", total=None)
+                # Get the authenticated user's ID
+                user = await client.get_user()
+                ws_id = await _resolve_workspace_id(client, workspace_id)
 
-                    # Get the authenticated user's ID
-                    user = await client.get_user()
-                    ws_id = await _resolve_workspace_id(client, workspace_id)
-
-                    # Search for tasks assigned to this user across the workspace
-                    # ClickUp API expects assignees[] as repeated query params
-                    tasks = await client.search_tasks(
-                        ws_id,
-                        "",
-                        **{"assignees[]": [str(user.id)]},
-                    )
-
+                # Search for tasks assigned to this user across the workspace
+                # ClickUp API expects assignees[] as repeated query params
+                tasks = await client.search_tasks(
+                    ws_id,
+                    "",
+                    **{"assignees[]": [str(user.id)]},
+                )
                 if not tasks:
                     render_message("No tasks assigned to you.", "warn")
                     return
@@ -242,14 +219,7 @@ def create_task(
                 task_data["status"] = status_to_use
 
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Creating task...", total=None)
-                    task = await client.create_task(list_id_to_use, **task_data)
-
+                task = await client.create_task(list_id_to_use, **task_data)
                 render_message(f"Created task: {task.name} (ID: {task.id})", "success")
                 if task.url:
                     render_message(f"URL: {task.url}", "info")
@@ -295,14 +265,7 @@ def update_task(
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Updating task...", total=None)
-                    task = await client.update_task(task_id, **updates)
-
+                task = await client.update_task(task_id, **updates)
                 render_message(f"Updated task: {task.name} (ID: {task.id})", "success")
 
         except ClickUpError as e:
@@ -332,14 +295,7 @@ def change_status(
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Updating task status...", total=None)
-                    task = await client.update_task(task_id, status=status)
-
+                task = await client.update_task(task_id, status=status)
                 render_message(f"Updated task status: {task.name} -> {status}", "success")
 
         except ClickUpError as e:
@@ -370,14 +326,7 @@ def delete_task(
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Deleting task...", total=None)
-                    await client.delete_task(task_id)
-
+                await client.delete_task(task_id)
                 render_message(f"Deleted task {task_id}", "success")
 
         except ClickUpError as e:
@@ -418,14 +367,7 @@ def search_tasks(
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Searching tasks...", total=None)
-                    tasks = await client.search_tasks(id_to_use, query)
-
+                tasks = await client.search_tasks(id_to_use, query)
                 if not tasks:
                     render_message(f"No tasks found matching '{query}'", "warn")
                     return
@@ -459,19 +401,11 @@ def export_tasks(
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Exporting tasks...", total=None)
+                filters: dict[str, Any] = {}
+                if not include_completed:
+                    filters["include_closed"] = False
 
-                    filters: dict[str, Any] = {}
-                    if not include_completed:
-                        filters["include_closed"] = False
-
-                    tasks = await client.get_tasks(list_id_to_use, **filters)
-
+                tasks = await client.get_tasks(list_id_to_use, **filters)
                 if format.lower() == "json":
                     import json
 
@@ -539,14 +473,7 @@ def list_comments(
     async def _list_comments() -> None:
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Fetching comments...", total=None)
-                    comments = await client.get_task_comments(task_id)
-
+                comments = await client.get_task_comments(task_id)
                 if not comments:
                     render_message(f"No comments on task {task_id}.", "warn")
                     return
@@ -571,14 +498,7 @@ def add_comment(
     async def _add_comment() -> None:
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Adding comment...", total=None)
-                    comment = await client.create_comment(task_id, text)
-
+                comment = await client.create_comment(task_id, text)
                 render_message(f"Comment added (ID: {comment.id})", "success")
 
         except ClickUpError as e:

--- a/clickup/cli/commands/templates.py
+++ b/clickup/cli/commands/templates.py
@@ -11,7 +11,7 @@ from rich.table import Table
 
 from ...core import ClickUpClient, ClickUpError, Config
 from ..output import render_error
-from ..utils import Progress, SpinnerColumn, TextColumn, run_async
+from ..utils import run_async
 
 app = typer.Typer(help="Template management")
 console = Console()
@@ -381,17 +381,9 @@ def create_from_template(
         # Create task
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Creating task from template...", total=None)
+                task_data = {"name": name, "description": description, "priority": priority}
 
-                    task_data = {"name": name, "description": description, "priority": priority}
-
-                    task = await client.create_task(list_id_to_use, **task_data)
-
+                task = await client.create_task(list_id_to_use, **task_data)
                 console.print(f"✅ Created task from template: {task.name}")
                 console.print(f"🆔 Task ID: {task.id}")
                 if task.url:
@@ -433,14 +425,7 @@ def save_template(
     async def _save_template() -> None:
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Fetching task...", total=None)
-                    task = await client.get_task(task_id)
-
+                task = await client.get_task(task_id)
                 template: dict[str, Any] = {
                     "name": task.name,
                     "description": task.description or "",

--- a/clickup/cli/commands/workspace.py
+++ b/clickup/cli/commands/workspace.py
@@ -2,11 +2,10 @@
 
 import typer
 from rich.console import Console
-from rich.table import Table
 
 from ...core import ClickUpClient, ClickUpError, Config
-from ..output import render_error
-from ..utils import Progress, SpinnerColumn, TextColumn, run_async
+from ..output import render_error, render_folders, render_message, render_spaces, render_teams, render_users
+from ..utils import run_async
 
 app = typer.Typer(help="Workspace management")
 console = Console()
@@ -16,11 +15,11 @@ async def get_client() -> ClickUpClient:
     """Get configured ClickUp client."""
     config = Config()
     if not config.has_credentials():
-        console.print(
-            "[red]Error: No ClickUp API token configured. Set CLICKUP_API_KEY in your "
-            "environment (or .env), or run 'clickup config set-token <token>'.[/red]"
+        render_error(
+            "No ClickUp API token configured. "
+            "Set CLICKUP_API_KEY in your environment (or .env), or run 'clickup config set-token <token>'."
         )
-        raise typer.Exit(1) from None
+        raise typer.Exit(2) from None
     return ClickUpClient(config, console)
 
 
@@ -31,32 +30,16 @@ def list_workspaces() -> None:
     async def _list_workspaces() -> None:
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Fetching workspaces...", total=None)
-                    teams = await client.get_teams()
-
+                teams = await client.get_teams()
                 if not teams:
-                    console.print("[yellow]No workspaces found.[/yellow]")
+                    render_message("No workspaces found.", "warn")
                     return
-
-                table = Table(title="Workspaces", show_header=True)
-                table.add_column("ID", style="cyan")
-                table.add_column("Name", style="bold")
-                table.add_column("Color", style="green")
-                table.add_column("Members", style="blue")
-
-                for team in teams:
-                    table.add_row(team.id, team.name, team.color, str(len(team.members)))
-
-                console.print(table)
-
+                render_teams(teams)
         except ClickUpError as e:
             render_error(f"ClickUp API Error: {e}")
             raise typer.Exit(1) from None
+        except typer.Exit:
+            raise
         except Exception as e:
             render_error(f"An unexpected error occurred: {e}")
             raise typer.Exit(1) from e
@@ -77,38 +60,24 @@ def list_spaces(
         workspace_id_to_use = workspace_id or team_id or config.get("default_team_id")
 
         if not workspace_id_to_use:
-            render_error("Error: No workspace ID provided and no default workspace configured.")
-            console.print("Use --workspace-id or set a default with 'clickup config set default_team_id <id>'")
-            raise typer.Exit(1) from None
+            render_error(
+                "No workspace ID provided and no default workspace configured. "
+                "Use --workspace-id or set a default with 'clickup config set default_team_id <id>'."
+            )
+            raise typer.Exit(2) from None
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Fetching spaces...", total=None)
-                    spaces = await client.get_spaces(workspace_id_to_use)
-
+                spaces = await client.get_spaces(workspace_id_to_use)
                 if not spaces:
-                    console.print("[yellow]No spaces found.[/yellow]")
+                    render_message("No spaces found.", "warn")
                     return
-
-                table = Table(title="Spaces", show_header=True)
-                table.add_column("ID", style="cyan")
-                table.add_column("Name", style="bold")
-                table.add_column("Private", style="yellow")
-                table.add_column("Statuses", style="green")
-
-                for space in spaces:
-                    table.add_row(space.id, space.name, "Yes" if space.private else "No", str(len(space.statuses)))
-
-                console.print(table)
-
+                render_spaces(spaces)
         except ClickUpError as e:
             render_error(f"ClickUp API Error: {e}")
             raise typer.Exit(1) from None
+        except typer.Exit:
+            raise
         except Exception as e:
             render_error(f"An unexpected error occurred: {e}")
             raise typer.Exit(1) from e
@@ -128,38 +97,24 @@ def list_folders(
         space_id_to_use = space_id or config.get("default_space_id")
 
         if not space_id_to_use:
-            render_error("Error: No space ID provided and no default space configured.")
-            console.print("Use --space-id or set a default with 'clickup config set default_space_id <id>'")
-            raise typer.Exit(1) from None
+            render_error(
+                "No space ID provided and no default space configured. "
+                "Use --space-id or set a default with 'clickup config set default_space_id <id>'."
+            )
+            raise typer.Exit(2) from None
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Fetching folders...", total=None)
-                    folders = await client.get_folders(space_id_to_use)
-
+                folders = await client.get_folders(space_id_to_use)
                 if not folders:
-                    console.print("[yellow]No folders found.[/yellow]")
+                    render_message("No folders found.", "warn")
                     return
-
-                table = Table(title="Folders", show_header=True)
-                table.add_column("ID", style="cyan")
-                table.add_column("Name", style="bold")
-                table.add_column("Hidden", style="yellow")
-                table.add_column("Task Count", style="green")
-
-                for folder in folders:
-                    table.add_row(folder.id, folder.name, "Yes" if folder.hidden else "No", folder.task_count)
-
-                console.print(table)
-
+                render_folders(folders)
         except ClickUpError as e:
             render_error(f"ClickUp API Error: {e}")
             raise typer.Exit(1) from None
+        except typer.Exit:
+            raise
         except Exception as e:
             render_error(f"An unexpected error occurred: {e}")
             raise typer.Exit(1) from e
@@ -180,45 +135,24 @@ def list_members(
         workspace_id_to_use = workspace_id or team_id or config.get("default_team_id")
 
         if not workspace_id_to_use:
-            render_error("Error: No workspace ID provided and no default workspace configured.")
-            console.print("Use --workspace-id or set a default with 'clickup config set default_team_id <id>'")
-            raise typer.Exit(1) from None
+            render_error(
+                "No workspace ID provided and no default workspace configured. "
+                "Use --workspace-id or set a default with 'clickup config set default_team_id <id>'."
+            )
+            raise typer.Exit(2) from None
 
         try:
             async with await get_client() as client:
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,
-                ) as progress:
-                    progress.add_task("Fetching members...", total=None)
-                    members = await client.get_team_members(workspace_id_to_use)
-
+                members = await client.get_team_members(workspace_id_to_use)
                 if not members:
-                    console.print("[yellow]No members found.[/yellow]")
+                    render_message("No members found.", "warn")
                     return
-
-                table = Table(title="Workspace Members", show_header=True)
-                table.add_column("ID", style="cyan")
-                table.add_column("Username", style="bold")
-                table.add_column("Email", style="green")
-                table.add_column("Role", style="magenta")
-                table.add_column("Color", style="yellow")
-
-                for member in members:
-                    table.add_row(
-                        str(member.id),
-                        member.username,
-                        member.email,
-                        str(member.role) if member.role is not None else "None",
-                        member.color or "None",
-                    )
-
-                console.print(table)
-
+                render_users(members, title="Workspace Members")
         except ClickUpError as e:
             render_error(f"ClickUp API Error: {e}")
             raise typer.Exit(1) from None
+        except typer.Exit:
+            raise
         except Exception as e:
             render_error(f"An unexpected error occurred: {e}")
             raise typer.Exit(1) from e

--- a/clickup/cli/main.py
+++ b/clickup/cli/main.py
@@ -34,8 +34,10 @@ def _root_callback(
     output_format: FormatChoice | None = _FORMAT_OPTION,
 ) -> None:
     """ClickUp CLI - Task management from the command line."""
-    if output_format is not None:
-        set_format(output_format)
+    # Reset format every invocation so module-level state doesn't bleed across
+    # repeated CliRunner.invoke() calls in tests (and across long-running
+    # processes that re-enter the CLI).
+    set_format(output_format if output_format is not None else FormatChoice.table)
 
 
 # -- Get started --------------------------------------------------------

--- a/clickup/cli/output.py
+++ b/clickup/cli/output.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from rich.markup import escape
 from rich.table import Table
 
-from ..core.models import Comment, Space, Task, Team, User
+from ..core.models import Comment, Folder, Space, Task, Team, User
 from ..core.models import List as ClickUpList
 
 # ---------------------------------------------------------------------------
@@ -254,6 +254,94 @@ def render_lists(lists: list[ClickUpList]) -> None:
     for lst in lists:
         table.add_row(lst.id, escape(lst.name), str(lst.task_count) if lst.task_count is not None else "N/A")
     _console.print(table)
+
+
+def render_folders(folders: list[Folder]) -> None:
+    """Render a list of Folders."""
+    if get_format() == "json":
+        _print_json({"data": [f.model_dump(mode="json") for f in folders], "count": len(folders)})
+        return
+    table = Table(title="Folders", show_header=True)
+    table.add_column("ID", style="cyan")
+    table.add_column("Name", style="bold")
+    table.add_column("Hidden", style="yellow")
+    table.add_column("Task Count", style="green")
+    for folder in folders:
+        table.add_row(folder.id, escape(folder.name), "Yes" if folder.hidden else "No", str(folder.task_count))
+    _console.print(table)
+
+
+def render_users(users: list[User], *, title: str = "Users") -> None:
+    """Render a list of Users (e.g. workspace members)."""
+    if get_format() == "json":
+        _print_json({"data": [u.model_dump(mode="json") for u in users], "count": len(users)})
+        return
+    table = Table(title=title, show_header=True)
+    table.add_column("ID", style="cyan")
+    table.add_column("Username", style="bold")
+    table.add_column("Email", style="green")
+    table.add_column("Role", style="magenta")
+    table.add_column("Color", style="yellow")
+    for u in users:
+        table.add_row(
+            str(u.id),
+            escape(u.username),
+            escape(u.email),
+            str(u.role) if u.role is not None else "None",
+            u.color or "None",
+        )
+    _console.print(table)
+
+
+def render_hierarchy(data: dict[str, Any]) -> None:
+    """Render a nested workspace → space → folder → list hierarchy.
+
+    ``data`` shape::
+
+        {
+            "workspaces": [
+                {
+                    "id": ..., "name": ...,
+                    "spaces": [
+                        {
+                            "id": ..., "name": ...,
+                            "folders": [
+                                {"id": ..., "name": ..., "lists": [{"id": ..., "name": ..., "task_count": N}]}
+                            ],
+                            "folderless_lists": [{"id": ..., "name": ..., "task_count": N}]
+                        }
+                    ]
+                }
+            ]
+        }
+    """
+    if get_format() == "json":
+        _print_json(data)
+        return
+
+    from rich.tree import Tree
+
+    tree = Tree("🏢 ClickUp Hierarchy")
+    for workspace in data.get("workspaces", []):
+        ws_node = tree.add(f"🏢 [bold cyan]{escape(workspace['name'])}[/bold cyan] ([dim]{workspace['id']}[/dim])")
+        for space in workspace.get("spaces", []):
+            sp_node = ws_node.add(f"📁 [blue]{escape(space['name'])}[/blue] ([dim]{space['id']}[/dim])")
+            for folder in space.get("folders", []):
+                f_node = sp_node.add(f"📂 [yellow]{escape(folder['name'])}[/yellow] ([dim]{folder['id']}[/dim])")
+                for lst in folder.get("lists", []):
+                    f_node.add(
+                        f"📋 [green]{escape(lst['name'])}[/green] ([dim]{lst['id']}[/dim]) - "
+                        f"{lst.get('task_count', '?')} tasks"
+                    )
+            folderless = space.get("folderless_lists", [])
+            if folderless:
+                fl_node = sp_node.add("📂 [yellow]Folderless Lists[/yellow]")
+                for lst in folderless:
+                    fl_node.add(
+                        f"📋 [green]{escape(lst['name'])}[/green] ([dim]{lst['id']}[/dim]) - "
+                        f"{lst.get('task_count', '?')} tasks"
+                    )
+    _console.print(tree)
 
 
 def render_task(task: Task) -> None:

--- a/clickup/cli/utils.py
+++ b/clickup/cli/utils.py
@@ -3,60 +3,9 @@
 import asyncio
 import concurrent.futures
 from collections.abc import Coroutine
-from contextlib import contextmanager
 from typing import Any, TypeVar
 
 T = TypeVar("T")
-
-
-class _NullProgress:
-    """No-op stand-in for rich.progress.Progress.
-
-    The CLI is consumed primarily by AI agents and pipes; spinner frames on
-    stdout corrupt --format json output and are useless to non-interactive
-    callers. This class lets existing `with Progress(...): progress.add_task(...)`
-    call sites compile and execute without producing any output.
-    """
-
-    def __enter__(self) -> "_NullProgress":
-        return self
-
-    def __exit__(self, *args: Any) -> None:
-        return None
-
-    def add_task(self, *args: Any, **kwargs: Any) -> int:
-        return 0
-
-    def update(self, *args: Any, **kwargs: Any) -> None:
-        return None
-
-    def advance(self, *args: Any, **kwargs: Any) -> None:
-        return None
-
-
-def Progress(*_args: Any, **_kwargs: Any) -> _NullProgress:  # noqa: N802
-    """Drop-in shim for rich.progress.Progress that does nothing."""
-    return _NullProgress()
-
-
-def SpinnerColumn(*_args: Any, **_kwargs: Any) -> None:  # noqa: N802
-    """Drop-in shim — accepts and discards any args."""
-    return None
-
-
-def TextColumn(*_args: Any, **_kwargs: Any) -> None:  # noqa: N802
-    """Drop-in shim — accepts and discards any args."""
-    return None
-
-
-def BarColumn(*_args: Any, **_kwargs: Any) -> None:  # noqa: N802
-    """Drop-in shim — accepts and discards any args."""
-    return None
-
-
-def TaskProgressColumn(*_args: Any, **_kwargs: Any) -> None:  # noqa: N802
-    """Drop-in shim — accepts and discards any args."""
-    return None
 
 
 def run_async(coro: Coroutine[Any, Any, T]) -> T:  # noqa: UP047
@@ -100,9 +49,3 @@ def run_async(coro: Coroutine[Any, Any, T]) -> T:  # noqa: UP047
                     return future.result(timeout=30)
             else:
                 raise
-
-
-@contextmanager
-def spinner(_description: str = "Working...") -> Any:
-    """No-op spinner shim, kept so callers don't break."""
-    yield _NullProgress()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ indent-style = "space"
 [tool.ty.environment]
 python-version = "3.12"
 
+[tool.ty.src]
+exclude = ["tests/**"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v --cov=clickup --cov-report=term-missing --ignore=tests/live"

--- a/tests/integration/test_command_coverage.py
+++ b/tests/integration/test_command_coverage.py
@@ -1,0 +1,515 @@
+"""Coverage-driven tests for templates / discover / config / main / list / workspace.
+
+Each test exercises a previously-uncovered command path. Many are smoke tests
+for table mode; JSON-mode coverage lives in test_json_format.py.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+from typer.testing import CliRunner
+
+from clickup.cli.main import app
+from clickup.core.models import (
+    List as ClickUpList,
+)
+from clickup.core.models import (
+    PriorityInfo,
+    Task,
+)
+
+runner = CliRunner()
+
+
+def _ctx(client):
+    cm = AsyncMock()
+    cm.__aenter__.return_value = client
+    return cm
+
+
+def _named(**kw):
+    name = kw.pop("name", None)
+    m = Mock(**kw)
+    if name is not None:
+        m.name = name
+    return m
+
+
+# =============================================================================
+# templates
+# =============================================================================
+
+
+def test_templates_list_builtin():
+    """Built-in templates render in table mode."""
+    result = runner.invoke(app, ["template", "list"])
+    assert result.exit_code == 0
+    assert "bug_report" in result.output
+    assert "feature_request" in result.output
+
+
+def test_templates_show_builtin():
+    result = runner.invoke(app, ["template", "show", "bug_report"])
+    assert result.exit_code == 0
+    assert "Bug Description" in result.output
+
+
+def test_templates_show_missing():
+    result = runner.invoke(app, ["template", "show", "nonexistent_xyz"])
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+@patch("clickup.cli.commands.templates.get_client")
+def test_templates_create_with_variables_file(mock_get_client):
+    """Use --variables file path with all bug_report vars."""
+    mock_client = AsyncMock()
+    mock_client.create_task.return_value = Task(id="t1", name="[Bug] login")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    bug_vars = {
+        "title": "login",
+        "description": "broken",
+        "step1": "x",
+        "step2": "y",
+        "step3": "z",
+        "expected": "ok",
+        "actual": "fail",
+        "environment": "mac",
+        "version": "1.0",
+        "attachments": "none",
+        "severity": "high",
+    }
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(bug_vars, f)
+        f.flush()
+        result = runner.invoke(
+            app,
+            [
+                "template",
+                "create",
+                "--template",
+                "bug_report",
+                "--list-id",
+                "L1",
+                "--variables",
+                f.name,
+                "--no-interactive",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "Created task" in result.output
+
+
+@patch("clickup.cli.commands.templates.get_client")
+def test_templates_create_invalid_var_format(mock_get_client):
+    mock_client = AsyncMock()
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        [
+            "template",
+            "create",
+            "--template",
+            "bug_report",
+            "--list-id",
+            "L1",
+            "--var",
+            "no_equals_sign",
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Invalid variable format" in result.output
+
+
+@patch("clickup.cli.commands.templates.get_client")
+def test_templates_save_with_pattern_flags(mock_get_client):
+    """Non-interactive save with --name-pattern / --description-pattern."""
+    mock_client = AsyncMock()
+    mock_client.get_task.return_value = Task(
+        id="t1", name="Sample task", description="Sample {what}", priority=PriorityInfo(priority="2", id="2")
+    )
+    mock_get_client.return_value = _ctx(mock_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.cli.commands.templates.Path.home", return_value=Path(tmpdir)):
+            result = runner.invoke(
+                app,
+                [
+                    "template",
+                    "save",
+                    "test-template",
+                    "--from-task",
+                    "t1",
+                    "--name-pattern",
+                    "[{kind}] {title}",
+                    "--description-pattern",
+                    "Doing {what}",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "Saved template" in result.output
+
+
+def test_templates_create_no_list_errors():
+    result = runner.invoke(app, ["template", "create", "--template", "bug_report", "--no-interactive"])
+    assert result.exit_code != 0
+
+
+def test_templates_create_no_template_errors():
+    result = runner.invoke(app, ["template", "create", "--list-id", "L1", "--no-interactive"])
+    assert result.exit_code != 0
+
+
+# =============================================================================
+# discover ids / path
+# =============================================================================
+
+
+@patch("clickup.cli.commands.discover.get_client")
+def test_discover_ids_lists_in_folder(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_lists.return_value = [_named(id="L1", name="Sprint", task_count=5)]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["discover", "ids", "--folder-id", "F1"])
+    assert result.exit_code == 0
+    assert "Sprint" in result.output
+
+
+@patch("clickup.cli.commands.discover.get_client")
+def test_discover_ids_in_space(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_folders.return_value = [_named(id="F1", name="Backend", task_count=10)]
+    mock_client.get_folderless_lists.return_value = [_named(id="L1", name="Loose", task_count=2)]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["discover", "ids", "--space-id", "S1"])
+    assert result.exit_code == 0
+    assert "Backend" in result.output
+    assert "Loose" in result.output
+
+
+@patch("clickup.cli.commands.discover.get_client")
+def test_discover_ids_in_workspace(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_spaces.return_value = [_named(id="S1", name="Eng", private=False, statuses=[])]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["discover", "ids", "--workspace-id", "W1"])
+    assert result.exit_code == 0
+    assert "Eng" in result.output
+
+
+@patch("clickup.cli.commands.discover.get_client")
+def test_discover_ids_no_args_lists_workspaces(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_teams.return_value = [_named(id="T1", name="Acme", color="#fff", members=[])]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["discover", "ids"])
+    assert result.exit_code == 0
+    assert "Acme" in result.output
+
+
+@patch("clickup.cli.commands.discover.get_client")
+def test_discover_path_finds_list(mock_get_client):
+    mock_client = AsyncMock()
+    workspace = _named(id="W1", name="Acme")
+    space = _named(id="S1", name="Eng")
+    target_list = _named(id="L1", name="Sprint")
+    mock_client.get_list.return_value = target_list
+    mock_client.get_teams.return_value = [workspace]
+    mock_client.get_spaces.return_value = [space]
+    mock_client.get_folderless_lists.return_value = [target_list]
+    mock_client.get_folders.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["discover", "path", "L1"])
+    assert result.exit_code == 0
+    assert "Sprint" in result.output
+
+
+# =============================================================================
+# config: show / whoami / validate / set-client-id / set-client-secret
+# =============================================================================
+
+
+def test_config_set_client_id():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            result = runner.invoke(app, ["config", "set-client-id", "client_123"])
+            assert result.exit_code == 0
+            assert "Client ID configured" in result.output
+
+
+def test_config_set_client_secret():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            result = runner.invoke(app, ["config", "set-client-secret", "secret_456"])
+            assert result.exit_code == 0
+
+
+def test_config_get_unset():
+    """`config get` on missing key prints not-set message."""
+    result = runner.invoke(app, ["config", "get", "nonexistent_key_xyz"])
+    assert result.exit_code == 0
+    assert "not set" in result.output
+
+
+def test_config_show():
+    result = runner.invoke(app, ["config", "show"])
+    assert result.exit_code == 0
+
+
+def test_config_clean_no_unknowns():
+    """Clean is a no-op when there are no unknown keys."""
+    result = runner.invoke(app, ["config", "clean"])
+    assert result.exit_code == 0
+    assert "clean" in result.output.lower()
+
+
+def test_config_clean_dry_run():
+    """Plant an unknown key, then dry-run shouldn't remove it or refuse."""
+    from clickup.core import Config
+
+    cfg = Config()
+    cfg_path = Path(cfg._get_config_path())
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps({"default_team_id": "T1", "_garbage": "xx"}))
+
+    result = runner.invoke(app, ["config", "clean", "--dry-run"])
+    assert result.exit_code == 0
+    assert "Dry run" in result.output
+
+
+def test_config_clean_with_force_removes():
+    from clickup.core import Config
+
+    cfg = Config()
+    cfg_path = Path(cfg._get_config_path())
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps({"default_team_id": "T1", "_garbage": "xx"}))
+
+    result = runner.invoke(app, ["config", "clean", "--force"])
+    assert result.exit_code == 0
+    assert "Removed" in result.output
+
+
+def test_config_set_default_list():
+    result = runner.invoke(app, ["config", "set-default-list", "myalias", "12345"])
+    assert result.exit_code == 0
+    assert "myalias" in result.output
+
+
+def test_config_set_default_list_remove():
+    runner.invoke(app, ["config", "set-default-list", "myalias", "12345"])
+    result = runner.invoke(app, ["config", "set-default-list", "--remove", "myalias"])
+    assert result.exit_code == 0
+    assert "Removed" in result.output
+
+
+def test_config_set_default_list_remove_missing_errors():
+    result = runner.invoke(app, ["config", "set-default-list", "--remove", "nonexistent"])
+    assert result.exit_code != 0
+
+
+def test_config_set_default_list_no_id_errors():
+    result = runner.invoke(app, ["config", "set-default-list", "myalias"])
+    assert result.exit_code != 0
+    assert "list_id" in result.output
+
+
+# =============================================================================
+# list commands
+# =============================================================================
+
+
+@patch("clickup.cli.commands.list.get_client")
+def test_list_show_in_folder(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_lists.return_value = [ClickUpList(id="L1", name="Sprint", task_count=5)]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["list", "show", "--folder-id", "F1"])
+    assert result.exit_code == 0
+    assert "Sprint" in result.output
+
+
+@patch("clickup.cli.commands.list.get_client")
+def test_list_show_in_space(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_folderless_lists.return_value = [ClickUpList(id="L1", name="Sprint", task_count=5)]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["list", "show", "--space-id", "S1"])
+    assert result.exit_code == 0
+    assert "Sprint" in result.output
+
+
+def test_list_show_no_args_errors():
+    result = runner.invoke(app, ["list", "show"])
+    assert result.exit_code != 0
+
+
+@patch("clickup.cli.commands.list.get_client")
+def test_list_get(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_list.return_value = ClickUpList(
+        id="L1",
+        name="Sprint",
+        task_count=5,
+        content="some content",
+        orderindex=0,
+    )
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["list", "get", "--list-id", "L1"])
+    assert result.exit_code == 0
+    assert "Sprint" in result.output
+
+
+@patch("clickup.cli.commands.list.get_client")
+def test_list_create_in_folder(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.create_list.return_value = ClickUpList(id="L1", name="New", task_count=0)
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["list", "create", "New", "--folder-id", "F1"])
+    assert result.exit_code == 0
+
+
+@patch("clickup.cli.commands.list.get_client")
+def test_list_create_in_space(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.create_folderless_list.return_value = ClickUpList(id="L1", name="New", task_count=0)
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["list", "create", "New", "--space-id", "S1"])
+    assert result.exit_code == 0
+
+
+def test_list_create_no_parent_errors():
+    result = runner.invoke(app, ["list", "create", "New"])
+    assert result.exit_code != 0
+
+
+# =============================================================================
+# main / top-level callbacks
+# =============================================================================
+
+
+def test_cli_help():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "ClickUp" in result.output
+
+
+def test_cli_version_or_status():
+    """Either --version or `status` should respond. Just smoke."""
+    result = runner.invoke(app, ["status"])
+    # status may exit non-zero without creds, but should produce output
+    assert result.output  # non-empty
+
+
+def test_cli_format_flag_global():
+    """--format json is accepted at the root level."""
+    result = runner.invoke(app, ["--format", "json", "template", "list"])
+    assert result.exit_code == 0
+    # Output may be a table for list templates if the command isn't fully migrated,
+    # but the global flag should at least be accepted without error.
+
+
+def test_invalid_subcommand_errors():
+    result = runner.invoke(app, ["nonexistent_subcommand"])
+    assert result.exit_code != 0
+
+
+# =============================================================================
+# bulk: extra coverage
+# =============================================================================
+
+
+@patch("clickup.cli.commands.bulk.get_client")
+def test_bulk_export_csv(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_tasks.return_value = [Task(id="t1", name="One")]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        result = runner.invoke(
+            app,
+            ["bulk", "export-tasks", "--list-id", "L1", "--output", f.name, "--format", "csv"],
+        )
+    assert result.exit_code == 0
+
+
+@patch("clickup.cli.commands.bulk.get_client")
+def test_bulk_import_dry_run_no_force_required(mock_get_client):
+    """--dry-run should not require --force."""
+    mock_client = AsyncMock()
+    mock_get_client.return_value = _ctx(mock_client)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump([{"name": "t1"}, {"name": "t2"}], f)
+        f.flush()
+        result = runner.invoke(
+            app,
+            ["bulk", "import-tasks", f.name, "--list-id", "L1", "--dry-run"],
+        )
+    assert result.exit_code == 0
+
+
+# =============================================================================
+# workspace: error paths
+# =============================================================================
+
+
+@patch("clickup.cli.commands.workspace.get_client")
+def test_workspace_list_empty(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_teams.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["workspace", "list"])
+    assert result.exit_code == 0
+    assert "No workspaces" in result.output
+
+
+@patch("clickup.cli.commands.workspace.get_client")
+def test_workspace_spaces_empty(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_spaces.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["workspace", "spaces", "--workspace-id", "W1"])
+    assert result.exit_code == 0
+    assert "No spaces" in result.output
+
+
+@patch("clickup.cli.commands.workspace.get_client")
+def test_workspace_folders_empty(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_folders.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["workspace", "folders", "--space-id", "S1"])
+    assert result.exit_code == 0
+    assert "No folders" in result.output
+
+
+@patch("clickup.cli.commands.workspace.get_client")
+def test_workspace_members_empty(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_team_members.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["workspace", "members", "--workspace-id", "W1"])
+    assert result.exit_code == 0
+    assert "No members" in result.output

--- a/tests/integration/test_discovery_commands.py
+++ b/tests/integration/test_discovery_commands.py
@@ -10,14 +10,23 @@ from clickup.cli.main import app
 runner = CliRunner()
 
 
+def _named_mock(**kwargs):
+    """Build a Mock where `.name` is a real string (Mock(name=...) is special)."""
+    name = kwargs.pop("name", None)
+    m = Mock(**kwargs)
+    if name is not None:
+        m.name = name
+    return m
+
+
 @pytest.fixture
 def sample_hierarchy():
     """Sample workspace hierarchy for testing."""
     return {
-        "team": Mock(id="team123", name="Test Team", color="#FF0000", members=[]),
-        "spaces": [Mock(id="space123", name="Test Space", private=False, statuses=[])],
-        "folders": [Mock(id="folder123", name="Test Folder", task_count=10)],
-        "lists": [Mock(id="list123", name="Test List", task_count=5)],
+        "team": _named_mock(id="team123", name="Test Team", color="#FF0000", members=[]),
+        "spaces": [_named_mock(id="space123", name="Test Space", private=False, statuses=[])],
+        "folders": [_named_mock(id="folder123", name="Test Folder", task_count=10)],
+        "lists": [_named_mock(id="list123", name="Test List", task_count=5)],
     }
 
 
@@ -42,10 +51,10 @@ def test_discover_hierarchy(mock_get_client, sample_hierarchy):
     result = runner.invoke(app, ["discover", "hierarchy"])
 
     assert result.exit_code == 0
-    assert "Test Team" in result.stdout
-    assert "Test Space" in result.stdout
-    assert "Test Folder" in result.stdout
-    assert "Test List" in result.stdout
+    assert "Test Team" in result.output
+    assert "Test Space" in result.output
+    assert "Test Folder" in result.output
+    assert "Test List" in result.output
 
 
 @patch("clickup.cli.commands.discover.get_client")
@@ -61,7 +70,7 @@ async def test_discover_hierarchy_with_team_filter(mock_get_client, sample_hiera
     result = runner.invoke(app, ["discover", "hierarchy", "--team-id", "team123"])
 
     assert result.exit_code == 0
-    assert "Test Team" in result.stdout
+    assert "Test Team" in result.output
 
 
 @patch("clickup.cli.commands.discover.get_client")

--- a/tests/integration/test_final_coverage.py
+++ b/tests/integration/test_final_coverage.py
@@ -1,0 +1,523 @@
+"""Final coverage push: setup interactive paths, bulk error paths, discover path."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from clickup.cli.main import app
+from clickup.cli.output import set_format
+from clickup.core.exceptions import ClickUpError
+from clickup.core.models import Task
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_format():
+    set_format("table")
+    yield
+    set_format("table")
+
+
+def _ctx(client):
+    cm = AsyncMock()
+    cm.__aenter__.return_value = client
+    return cm
+
+
+def _named(**kw):
+    name = kw.pop("name", None)
+    m = Mock(**kw)
+    if name is not None:
+        m.name = name
+    return m
+
+
+# ---------- setup interactive paths -----------------------------------------
+
+
+@patch("clickup.cli.commands.setup.typer.prompt")
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_interactive_token_prompt(mock_client_cls, mock_prompt):
+    """User enters a valid token at the prompt."""
+    mock_prompt.return_value = "pk_entered"
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (True, "ok", _named(id=1, username="u", email="u@x.com"))
+    mock_client.get_teams.return_value = [_named(id="T1", name="A")]
+    mock_client.get_spaces.return_value = [_named(id="S1", name="X")]
+    mock_client.get_folders.return_value = []
+    mock_client.get_folderless_lists.return_value = []
+    mock_client.get_tasks.return_value = []
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            result = runner.invoke(app, ["setup", "run"])
+            assert result.exit_code == 0
+            assert mock_prompt.called
+
+
+@patch("clickup.cli.commands.setup.typer.prompt")
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_interactive_pick_workspace_menu(mock_client_cls, mock_prompt):
+    """Two workspaces -> _pick_from_menu prompts for selection."""
+    mock_prompt.return_value = "1"  # always pick first
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (True, "ok", _named(id=1, username="u", email="u@x.com"))
+    teams = [_named(id="T1", name="A"), _named(id="T2", name="B")]
+    spaces = [_named(id="S1", name="X")]
+    mock_client.get_teams.return_value = teams
+    mock_client.get_spaces.return_value = spaces
+    mock_client.get_folders.return_value = []
+    mock_client.get_folderless_lists.return_value = []
+    mock_client.get_tasks.return_value = []
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["setup", "run", "--token", "pk"])
+    assert result.exit_code == 0
+    # Picked first team via the menu
+    assert "A" in result.output
+
+
+@patch("clickup.cli.commands.setup.typer.confirm")
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_interactive_list_use_suggested(mock_client_cls, mock_confirm):
+    """confirm=Yes accepts the suggested list."""
+    mock_confirm.return_value = True
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (True, "ok", _named(id=1, username="u", email="u@x.com"))
+    mock_client.get_teams.return_value = [_named(id="T1", name="A")]
+    mock_client.get_spaces.return_value = [_named(id="S1", name="X")]
+    mock_client.get_folders.return_value = []
+    mock_client.get_folderless_lists.return_value = [
+        _named(id="L1", name="High", task_count=10),
+        _named(id="L2", name="Low", task_count=2),
+    ]
+    mock_client.get_tasks.return_value = []
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["setup", "run", "--token", "pk"])
+    assert result.exit_code == 0
+    assert "High" in result.output
+
+
+@patch("clickup.cli.commands.setup.typer.prompt")
+@patch("clickup.cli.commands.setup.typer.confirm")
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_interactive_list_pick_alternative(mock_client_cls, mock_confirm, mock_prompt):
+    """confirm=No, then user enters a list number."""
+    mock_confirm.return_value = False
+    mock_prompt.return_value = "2"  # pick the second list
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (True, "ok", _named(id=1, username="u", email="u@x.com"))
+    mock_client.get_teams.return_value = [_named(id="T1", name="A")]
+    mock_client.get_spaces.return_value = [_named(id="S1", name="X")]
+    mock_client.get_folders.return_value = []
+    mock_client.get_folderless_lists.return_value = [
+        _named(id="L1", name="High", task_count=10),
+        _named(id="L2", name="Low", task_count=2),
+    ]
+    mock_client.get_tasks.return_value = []
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["setup", "run", "--token", "pk"])
+    assert result.exit_code == 0
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_token_validation_then_smoke_test(mock_client_cls):
+    """End-to-end happy path: token works, defaults set, smoke test fetches tasks."""
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (True, "ok", _named(id=1, username="u", email="u@x.com"))
+    mock_client.get_teams.return_value = [_named(id="T1", name="A")]
+    mock_client.get_spaces.return_value = [_named(id="S1", name="X")]
+    mock_client.get_folders.return_value = []
+    mock_client.get_folderless_lists.return_value = [_named(id="L1", name="Sprint", task_count=5)]
+    mock_client.get_tasks.return_value = [
+        Mock(name="task one", status=Mock(status="open")),
+        Mock(name="task two", status=Mock(status="open")),
+    ]
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["setup", "run", "--token", "pk", "--list-id", "L1", "--non-interactive"],
+    )
+    assert result.exit_code == 0
+    assert "smoke test" in result.output.lower()
+
+
+# ---------- bulk error paths ------------------------------------------------
+
+
+@patch("clickup.cli.commands.bulk.get_client")
+def test_bulk_import_invalid_format(mock_get_client):
+    mock_client = AsyncMock()
+    mock_get_client.return_value = _ctx(mock_client)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+        f.write("<x/>")
+        f.flush()
+        result = runner.invoke(app, ["bulk", "import-tasks", f.name, "--list-id", "L1"])
+    assert result.exit_code != 0
+    assert "Unsupported" in result.output or "format" in result.output.lower()
+
+
+@patch("clickup.cli.commands.bulk.get_client")
+def test_bulk_import_empty_file(mock_get_client):
+    mock_client = AsyncMock()
+    mock_get_client.return_value = _ctx(mock_client)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump([], f)
+        f.flush()
+        result = runner.invoke(app, ["bulk", "import-tasks", f.name, "--list-id", "L1"])
+    assert result.exit_code == 0
+    assert "No tasks found" in result.output
+
+
+@patch("clickup.cli.commands.bulk.get_client")
+def test_bulk_export_unsupported_format(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_tasks.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    with tempfile.NamedTemporaryFile(suffix=".xml") as f:
+        result = runner.invoke(
+            app,
+            ["bulk", "export-tasks", "--list-id", "L1", "--output", f.name, "--format", "xml"],
+        )
+    assert result.exit_code != 0
+
+
+@patch("clickup.cli.commands.bulk.get_client")
+def test_bulk_update_dry_run(mock_get_client):
+    mock_client = AsyncMock()
+    task = Mock()
+    task.id = "t1"
+    task.name = "X"
+    task.status = Mock()
+    task.status.get = Mock(return_value="todo")
+    task.priority = Mock()
+    task.priority.get = Mock(return_value="medium")
+    mock_client.get_tasks.return_value = [task]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["bulk", "bulk-update", "--list-id", "L1", "--status", "done", "--dry-run"])
+    assert result.exit_code == 0
+    assert "dry run" in result.output.lower()
+
+
+# ---------- discover path -----------------------------------------------------
+
+
+@patch("clickup.cli.commands.discover.get_client")
+def test_discover_path_in_folder(mock_get_client):
+    """Path traversal that finds the list inside a folder."""
+    mock_client = AsyncMock()
+    workspace = _named(id="W1", name="Acme")
+    space = _named(id="S1", name="Eng")
+    folder = _named(id="F1", name="Backend")
+    target = _named(id="L1", name="Sprint")
+    mock_client.get_list.return_value = target
+    mock_client.get_teams.return_value = [workspace]
+    mock_client.get_spaces.return_value = [space]
+    mock_client.get_folderless_lists.return_value = []
+    mock_client.get_folders.return_value = [folder]
+    mock_client.get_lists.return_value = [target]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["discover", "path", "L1"])
+    assert result.exit_code == 0
+    assert "Acme" in result.output
+    assert "Backend" in result.output
+
+
+@patch("clickup.cli.commands.discover.get_client")
+def test_discover_path_not_found(mock_get_client):
+    """Path that doesn't find the list anywhere."""
+    mock_client = AsyncMock()
+    mock_client.get_list.return_value = _named(id="L999", name="Missing")
+    mock_client.get_teams.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["discover", "path", "L999"])
+    assert result.exit_code == 0
+    assert "Could not find" in result.output
+
+
+# ---------- list create errors / api errors ---------------------------------
+
+
+@patch("clickup.cli.commands.list.get_client")
+def test_list_show_api_error(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_lists.side_effect = ClickUpError("nope")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["list", "show", "--folder-id", "F1"])
+    assert result.exit_code == 1
+
+
+@patch("clickup.cli.commands.list.get_client")
+def test_list_create_with_all_fields(mock_get_client):
+    """Exercise the create_list path with all option flags set."""
+    from clickup.core.models import List as ClickUpList
+
+    mock_client = AsyncMock()
+    mock_client.create_list.return_value = ClickUpList(id="L1", name="New", task_count=0)
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        [
+            "list",
+            "create",
+            "New",
+            "--folder-id",
+            "F1",
+            "--content",
+            "desc",
+            "--due-date",
+            "2026-12-01",
+            "--priority",
+            "2",
+            "--assignee",
+            "u1",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+# ---------- templates: list+show with custom dir ------------------------------
+
+
+def test_templates_list_with_include_custom():
+    """Test --include-custom flag with a real custom template on disk."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            with patch("clickup.cli.commands.templates.Path.home", return_value=Path(tmpdir)):
+                # Plant a custom template file
+                custom_dir = Path(tmpdir) / ".config" / "clickup-toolkit" / "templates"
+                custom_dir.mkdir(parents=True, exist_ok=True)
+                (custom_dir / "my_template.json").write_text(
+                    json.dumps({"name": "Custom {x}", "description": "d", "variables": ["x"]})
+                )
+
+                result = runner.invoke(app, ["template", "list", "--include-custom"])
+                assert result.exit_code == 0
+                assert "my_template" in result.output
+
+
+def test_templates_show_custom():
+    """Show a custom template loaded from disk."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            with patch("clickup.cli.commands.templates.Path.home", return_value=Path(tmpdir)):
+                custom_dir = Path(tmpdir) / ".config" / "clickup-toolkit" / "templates"
+                custom_dir.mkdir(parents=True, exist_ok=True)
+                (custom_dir / "test_t.json").write_text(
+                    json.dumps({"name": "T {x}", "description": "Desc", "priority": 2, "variables": ["x"]})
+                )
+
+                result = runner.invoke(app, ["template", "show", "test_t"])
+                assert result.exit_code == 0
+                assert "Custom" in result.output
+
+
+@patch("clickup.cli.commands.templates.get_client")
+def test_templates_create_with_template_file(mock_get_client):
+    """Provide a custom template file via --template-file."""
+    mock_client = AsyncMock()
+    mock_client.create_task.return_value = Task(id="t1", name="custom_task")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump({"name": "{x}", "description": "y", "priority": 3, "variables": ["x"]}, f)
+        f.flush()
+        result = runner.invoke(
+            app,
+            [
+                "template",
+                "create",
+                "--list-id",
+                "L1",
+                "--template-file",
+                f.name,
+                "--var",
+                "x=test",
+                "--no-interactive",
+            ],
+        )
+    assert result.exit_code == 0
+    assert "Created task" in result.output
+
+
+@patch("clickup.cli.commands.templates.get_client")
+def test_templates_create_template_file_missing(mock_get_client):
+    """A nonexistent --template-file path errors."""
+    mock_client = AsyncMock()
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        [
+            "template",
+            "create",
+            "--list-id",
+            "L1",
+            "--template-file",
+            "/nonexistent/path.json",
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Error loading template" in result.output
+
+
+@patch("clickup.cli.commands.templates.get_client")
+def test_templates_create_custom_template_by_name(mock_get_client):
+    """--template <name> resolves to a custom file on disk if not built-in."""
+    mock_client = AsyncMock()
+    mock_client.create_task.return_value = Task(id="t1", name="my_task")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.cli.commands.templates.Path.home", return_value=Path(tmpdir)):
+            custom_dir = Path(tmpdir) / ".config" / "clickup-toolkit" / "templates"
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            (custom_dir / "my_t.json").write_text(
+                json.dumps({"name": "{n}", "description": "d", "priority": 3, "variables": ["n"]})
+            )
+
+            result = runner.invoke(
+                app,
+                [
+                    "template",
+                    "create",
+                    "--list-id",
+                    "L1",
+                    "--template",
+                    "my_t",
+                    "--var",
+                    "n=foo",
+                    "--no-interactive",
+                ],
+            )
+            assert result.exit_code == 0
+
+
+@patch("clickup.cli.commands.templates.get_client")
+def test_templates_create_api_error(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.create_task.side_effect = ClickUpError("rate limit")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    bug_vars = {
+        "title": "x",
+        "description": "x",
+        "step1": "x",
+        "step2": "x",
+        "step3": "x",
+        "expected": "x",
+        "actual": "x",
+        "environment": "x",
+        "version": "x",
+        "attachments": "x",
+        "severity": "x",
+    }
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(bug_vars, f)
+        f.flush()
+        result = runner.invoke(
+            app,
+            [
+                "template",
+                "create",
+                "--template",
+                "bug_report",
+                "--list-id",
+                "L1",
+                "--variables",
+                f.name,
+                "--no-interactive",
+            ],
+        )
+    assert result.exit_code == 1
+    assert "rate limit" in result.stderr
+
+
+def test_templates_create_variables_file_missing():
+    """--variables file that doesn't exist errors out."""
+    result = runner.invoke(
+        app,
+        [
+            "template",
+            "create",
+            "--template",
+            "bug_report",
+            "--list-id",
+            "L1",
+            "--variables",
+            "/nonexistent.json",
+            "--no-interactive",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "variables file" in result.output.lower() or "error" in result.output.lower()
+
+
+# ---------- task error path: get -----------------------------------------------
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_get_api_error(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_task.side_effect = ClickUpError("not found")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "get", "t1"])
+    assert result.exit_code == 1
+    assert "not found" in result.stderr
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_list_api_error(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_tasks.side_effect = ClickUpError("rate limit")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "list", "--list-id", "L1"])
+    assert result.exit_code == 1
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_list_with_filters(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_tasks.return_value = [Task(id="t1", name="X")]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        [
+            "task",
+            "list",
+            "--list-id",
+            "L1",
+            "--status",
+            "open",
+            "--assignee",
+            "u1",
+            "--sort",
+            "created",
+            "--reverse",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "X" in result.output

--- a/tests/integration/test_json_format.py
+++ b/tests/integration/test_json_format.py
@@ -1,0 +1,202 @@
+"""JSON-format tests for the migrated commands (issue #15 acceptance).
+
+Each command runs in `--format json` mode and the output is parsed to confirm
+the contract shape (`{"data":[...],"count":N}` for collections,
+`model_dump(mode="json")` for singletons).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+from typer.testing import CliRunner
+
+from clickup.cli.main import app
+from clickup.core.models import (
+    Folder,
+    Space,
+    SpaceRef,
+    Team,
+    User,
+)
+from clickup.core.models import (
+    List as ClickUpList,
+)
+
+runner = CliRunner()
+
+
+def _user(**kw):
+    base = {"id": 1, "username": "u", "email": "u@x.com", "color": None}
+    base.update(kw)
+    return User(**base)
+
+
+def _team(**kw):
+    base = {"id": "T1", "name": "Acme", "color": "#000", "members": []}
+    base.update(kw)
+    return Team(**base)
+
+
+def _space(**kw):
+    base = {"id": "S1", "name": "Eng", "private": False, "statuses": [], "multiple_assignees": True}
+    base.update(kw)
+    return Space(**base)
+
+
+def _list(**kw):
+    base = {"id": "L1", "name": "Sprint", "task_count": 5}
+    base.update(kw)
+    return ClickUpList(**base)
+
+
+def _folder(**kw):
+    base = {
+        "id": "F1",
+        "name": "Backend",
+        "orderindex": 0,
+        "override_statuses": False,
+        "hidden": False,
+        "space": SpaceRef(id="S1", name="Eng"),
+        "task_count": "12",
+    }
+    base.update(kw)
+    return Folder(**base)
+
+
+def _ctx(client):
+    cm = AsyncMock()
+    cm.__aenter__.return_value = client
+    return cm
+
+
+# ---------- workspace --------------------------------------------------------
+
+
+@patch("clickup.cli.commands.workspace.get_client")
+def test_workspace_list_json(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_teams.return_value = [_team(), _team(id="T2", name="Other")]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["--format", "json", "workspace", "list"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data["count"] == 2
+    assert {t["name"] for t in data["data"]} == {"Acme", "Other"}
+
+
+@patch("clickup.cli.commands.workspace.get_client")
+def test_workspace_spaces_json(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_spaces.return_value = [_space()]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["--format", "json", "workspace", "spaces", "--workspace-id", "T1"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["count"] == 1
+    assert data["data"][0]["name"] == "Eng"
+
+
+@patch("clickup.cli.commands.workspace.get_client")
+def test_workspace_folders_json(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_folders.return_value = [_folder()]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["--format", "json", "workspace", "folders", "--space-id", "S1"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["count"] == 1
+    assert data["data"][0]["name"] == "Backend"
+
+
+@patch("clickup.cli.commands.workspace.get_client")
+def test_workspace_members_json(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_team_members.return_value = [_user(id=1, username="a"), _user(id=2, username="b")]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["--format", "json", "workspace", "members", "--workspace-id", "T1"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["count"] == 2
+    assert {u["username"] for u in data["data"]} == {"a", "b"}
+
+
+# ---------- discover hierarchy -----------------------------------------------
+
+
+def _named(**kw):
+    name = kw.pop("name", None)
+    m = Mock(**kw)
+    if name is not None:
+        m.name = name
+    return m
+
+
+@patch("clickup.cli.commands.discover.get_client")
+def test_discover_hierarchy_json(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_teams.return_value = [_named(id="T1", name="Acme")]
+    mock_client.get_spaces.return_value = [_named(id="S1", name="Eng")]
+    mock_client.get_folders.return_value = [_named(id="F1", name="Backend")]
+    mock_client.get_lists.return_value = [_named(id="L1", name="Sprint", task_count=5)]
+    mock_client.get_folderless_lists.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["--format", "json", "discover", "hierarchy", "--depth", "4"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data["workspaces"][0]["name"] == "Acme"
+    assert data["workspaces"][0]["spaces"][0]["name"] == "Eng"
+    assert data["workspaces"][0]["spaces"][0]["folders"][0]["name"] == "Backend"
+
+
+@patch("clickup.cli.commands.discover.get_client")
+def test_discover_hierarchy_table_no_crash(mock_get_client):
+    """Default table mode also works (regression for the Mock(name=...) bug)."""
+    mock_client = AsyncMock()
+    mock_client.get_teams.return_value = [_named(id="T1", name="Acme")]
+    mock_client.get_spaces.return_value = [_named(id="S1", name="Eng")]
+    mock_client.get_folders.return_value = []
+    mock_client.get_folderless_lists.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["discover", "hierarchy"])
+    assert result.exit_code == 0
+    assert "Acme" in result.output
+
+
+# ---------- task list (smoke) ------------------------------------------------
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_list_json(mock_get_client):
+    from clickup.core.models import Task
+
+    mock_client = AsyncMock()
+    mock_client.get_tasks.return_value = [Task(id="t1", name="One"), Task(id="t2", name="Two")]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["--format", "json", "task", "list", "--list-id", "L1"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["count"] == 2
+    assert {t["name"] for t in data["data"]} == {"One", "Two"}
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_get_json(mock_get_client):
+    from clickup.core.models import Task
+
+    mock_client = AsyncMock()
+    mock_client.get_task.return_value = Task(id="t1", name="One", description="d")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["--format", "json", "task", "get", "t1"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["name"] == "One"

--- a/tests/integration/test_main_coverage.py
+++ b/tests/integration/test_main_coverage.py
@@ -1,0 +1,162 @@
+"""Tests for top-level CLI commands in clickup/cli/main.py."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from clickup.cli.main import app
+from clickup.cli.output import set_format
+from clickup.core.models import List as ClickUpList
+from clickup.core.models import Space, Team
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_format():
+    """The global format state bleeds across test invocations — reset it."""
+    set_format("table")
+    yield
+    set_format("table")
+
+
+def _ctx(client):
+    cm = AsyncMock()
+    cm.__aenter__.return_value = client
+    return cm
+
+
+def test_version():
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert "v" in result.output.lower()
+
+
+def test_status_no_token():
+    """Status without a token reports it cleanly."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            result = runner.invoke(app, ["status"])
+            assert result.exit_code == 0
+            assert "No API token" in result.output
+
+
+@patch("clickup.cli.main.ClickUpClient")
+def test_status_with_valid_token(mock_client_cls):
+    """Status with valid token shows user info."""
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (True, "ok", Mock(username="evan", email="e@x.com"))
+    mock_client.get_teams.return_value = []
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            runner.invoke(app, ["config", "set-token", "pk_test"])
+            result = runner.invoke(app, ["status"])
+            assert result.exit_code == 0
+            assert "evan" in result.output
+
+
+@patch("clickup.cli.main.ClickUpClient")
+def test_status_with_full_defaults(mock_client_cls):
+    """Status resolves and displays default team / space / list names."""
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (True, "ok", Mock(username="evan", email="e@x.com"))
+    mock_client.get_team.return_value = Team(id="T1", name="Acme", color="#000", members=[])
+    mock_client.get_space.return_value = Space(id="S1", name="Eng", private=False, statuses=[], multiple_assignees=True)
+    mock_client.get_list.return_value = ClickUpList(id="L1", name="Sprint", task_count=5)
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            runner.invoke(app, ["config", "set-token", "pk_test"])
+            runner.invoke(app, ["config", "set", "default_team_id", "T1"])
+            runner.invoke(app, ["config", "set", "default_space_id", "S1"])
+            runner.invoke(app, ["config", "set", "default_list_id", "L1"])
+
+            result = runner.invoke(app, ["status"])
+            assert result.exit_code == 0
+            assert "Acme" in result.output
+            assert "Eng" in result.output
+            assert "Sprint" in result.output
+
+
+@patch("clickup.cli.main.ClickUpClient")
+def test_status_json(mock_client_cls):
+    """Status emits parseable JSON in --format json mode."""
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (True, "ok", Mock(username="e", email="e@x.com"))
+    mock_client.get_teams.return_value = []
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            runner.invoke(app, ["config", "set-token", "pk_test"])
+            result = runner.invoke(app, ["--format", "json", "status"])
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+            assert "auth_status" in data
+            assert "auth_valid" in data
+
+
+@patch("clickup.cli.main.ClickUpClient")
+def test_status_invalid_token(mock_client_cls):
+    """Status with an invalid token reports the failure."""
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (False, "bad token", None)
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            runner.invoke(app, ["config", "set-token", "pk_bogus"])
+            result = runner.invoke(app, ["status"])
+            assert result.exit_code == 0
+            assert "bad token" in result.output
+
+
+@patch("clickup.cli.main.ClickUpClient")
+def test_status_auto_detects_single_workspace(mock_client_cls):
+    """Status auto-detects implicit_team if exactly one workspace exists."""
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (True, "ok", Mock(username="e", email="e@x.com"))
+    mock_client.get_teams.return_value = [Team(id="W1", name="Solo", color="#000", members=[])]
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            runner.invoke(app, ["config", "set-token", "pk_test"])
+            result = runner.invoke(app, ["status"])
+            assert result.exit_code == 0
+            assert "Solo" in result.output
+            assert "auto-detected" in result.output
+
+
+@patch("clickup.cli.main.ClickUpClient")
+def test_status_partial_defaults(mock_client_cls):
+    """Status hints when some defaults are missing."""
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (True, "ok", Mock(username="e", email="e@x.com"))
+    mock_client.get_team.return_value = Team(id="T1", name="Acme", color="#000", members=[])
+    mock_client.get_teams.return_value = []
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            runner.invoke(app, ["config", "set-token", "pk_test"])
+            runner.invoke(app, ["config", "set", "default_team_id", "T1"])
+            result = runner.invoke(app, ["status"])
+            assert result.exit_code == 0
+            assert "setup run" in result.output  # hint to finish setup
+
+
+def test_help_shows_groups():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    # Help groups defined in main.py
+    assert "Get started" in result.output or "Task workflow" in result.output or "Workspace" in result.output

--- a/tests/integration/test_more_coverage.py
+++ b/tests/integration/test_more_coverage.py
@@ -1,0 +1,250 @@
+"""Additional tests to fill remaining coverage gaps.
+
+Targets: config validate / whoami, get_client error paths, bulk error paths,
+setup error paths, discover error paths.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from clickup.cli.main import app
+from clickup.cli.output import set_format
+from clickup.core.exceptions import ClickUpError
+from clickup.core.models import User
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_format():
+    set_format("table")
+    yield
+    set_format("table")
+
+
+def _ctx(client):
+    cm = AsyncMock()
+    cm.__aenter__.return_value = client
+    return cm
+
+
+# ---------- config validate / whoami -----------------------------------------
+
+
+@patch("clickup.cli.commands.config.ClickUpClient")
+def test_config_validate_valid_token(mock_client_cls):
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (
+        True,
+        "Authenticated",
+        User(id=1, username="evan", email="e@x.com", color="#fff", profilePicture="x"),
+    )
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            runner.invoke(app, ["config", "set-token", "pk_test"])
+            result = runner.invoke(app, ["config", "validate"])
+            assert result.exit_code == 0
+            assert "evan" in result.output
+
+
+@patch("clickup.cli.commands.config.ClickUpClient")
+def test_config_validate_invalid_token(mock_client_cls):
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (False, "bad token", None)
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            runner.invoke(app, ["config", "set-token", "pk_bogus"])
+            result = runner.invoke(app, ["config", "validate"])
+            assert result.exit_code != 0
+            assert "bad token" in result.output
+
+
+@patch("clickup.cli.commands.config.ClickUpClient")
+def test_config_validate_exception(mock_client_cls):
+    mock_client_cls.side_effect = Exception("network down")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            runner.invoke(app, ["config", "set-token", "pk_test"])
+            result = runner.invoke(app, ["config", "validate"])
+            assert result.exit_code != 0
+            assert "network down" in result.output
+
+
+@patch("clickup.cli.commands.config.ClickUpClient")
+def test_config_whoami_authenticated(mock_client_cls):
+    mock_client = AsyncMock()
+    mock_client.get_user.return_value = User(id=1, username="evan", email="e@x.com", color="#fff")
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            runner.invoke(app, ["config", "set-token", "pk_test"])
+            result = runner.invoke(app, ["config", "whoami"])
+            assert result.exit_code == 0
+            assert "evan" in result.output
+
+
+def test_config_whoami_no_credentials():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            with patch.dict("os.environ", {}, clear=False):
+                # Explicitly clear CLICKUP_*
+                from os import environ
+
+                for k in [k for k in environ if k.startswith("CLICKUP_")]:
+                    environ.pop(k, None)
+                result = runner.invoke(app, ["config", "whoami"])
+                assert result.exit_code != 0
+                assert "credentials" in result.output.lower()
+
+
+# ---------- get_client / no-credentials paths --------------------------------
+
+
+def test_workspace_list_no_credentials():
+    """Without a token, workspace list refuses with a setup hint."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            from os import environ
+
+            for k in [k for k in environ if k.startswith("CLICKUP_")]:
+                environ.pop(k, None)
+            result = runner.invoke(app, ["workspace", "list"])
+            assert result.exit_code != 0
+            assert "API token" in result.output
+
+
+def test_task_list_no_credentials():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            from os import environ
+
+            for k in [k for k in environ if k.startswith("CLICKUP_")]:
+                environ.pop(k, None)
+            result = runner.invoke(app, ["task", "list", "--list-id", "L1"])
+            assert result.exit_code != 0
+
+
+def test_discover_hierarchy_no_credentials():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
+            from os import environ
+
+            for k in [k for k in environ if k.startswith("CLICKUP_")]:
+                environ.pop(k, None)
+            result = runner.invoke(app, ["discover", "hierarchy"])
+            assert result.exit_code != 0
+
+
+# ---------- workspace error paths --------------------------------------------
+
+
+@patch("clickup.cli.commands.workspace.get_client")
+def test_workspace_list_api_error(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_teams.side_effect = ClickUpError("rate limited")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["workspace", "list"])
+    assert result.exit_code == 1
+    assert "rate limited" in result.stderr
+
+
+@patch("clickup.cli.commands.workspace.get_client")
+def test_workspace_list_unexpected_error(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_teams.side_effect = RuntimeError("kapow")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["workspace", "list"])
+    assert result.exit_code == 1
+    assert "kapow" in result.stderr
+
+
+# ---------- bulk error paths -------------------------------------------------
+
+
+@patch("clickup.cli.commands.bulk.get_client")
+def test_bulk_export_api_error(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_tasks.side_effect = ClickUpError("nope")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    with tempfile.NamedTemporaryFile(suffix=".json") as f:
+        result = runner.invoke(
+            app,
+            ["bulk", "export-tasks", "--list-id", "L1", "--output", f.name],
+        )
+    assert result.exit_code == 1
+    assert "nope" in result.stderr
+
+
+@patch("clickup.cli.commands.bulk.get_client")
+def test_bulk_update_no_updates_specified(mock_get_client):
+    mock_client = AsyncMock()
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["bulk", "bulk-update", "--list-id", "L1"])
+    assert result.exit_code != 0
+    assert "at least one update" in result.stderr.lower()
+
+
+@patch("clickup.cli.commands.bulk.get_client")
+def test_bulk_update_no_matches_warns(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_tasks.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["bulk", "bulk-update", "--list-id", "L1", "--status", "done", "--yes"])
+    assert result.exit_code == 0
+    assert "No tasks found" in result.output
+
+
+# ---------- setup error paths ------------------------------------------------
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_token_validation_fails_in_non_interactive(mock_client_cls):
+    """Bad --token in --non-interactive mode errors."""
+    mock_client = AsyncMock()
+    mock_client.validate_auth.return_value = (False, "rejected", None)
+    mock_client_cls.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["setup", "run", "--token", "pk_bad", "--non-interactive"])
+    assert result.exit_code == 2
+    assert "Token rejected" in result.stderr
+
+
+# ---------- discover error paths ---------------------------------------------
+
+
+@patch("clickup.cli.commands.discover.get_client")
+def test_discover_hierarchy_api_error(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_teams.side_effect = ClickUpError("server fault")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["discover", "hierarchy"])
+    assert result.exit_code == 1
+    assert "server fault" in result.stderr
+
+
+@patch("clickup.cli.commands.discover.get_client")
+def test_discover_ids_api_error(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_teams.side_effect = ClickUpError("server fault")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["discover", "ids"])
+    assert result.exit_code == 1

--- a/tests/integration/test_setup_wizard.py
+++ b/tests/integration/test_setup_wizard.py
@@ -1,0 +1,227 @@
+"""Tests for `clickup setup run` — non-interactive flag-driven flows.
+
+The wizard is interactive by default but accepts --token / --team-id /
+--space-id / --list-id / --non-interactive for agent use. These tests pin
+both behaviors and exercise the auto-selection / mismatch / refusal paths.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+from typer.testing import CliRunner
+
+from clickup.cli.main import app
+
+runner = CliRunner()
+
+
+def _named(**kw):
+    """Build a Mock where `.name` is a real string."""
+    name = kw.pop("name", None)
+    m = Mock(**kw)
+    if name is not None:
+        m.name = name
+    return m
+
+
+def _mock_client(*, validate_ok=True, teams=None, spaces=None, lists=None, folders=None, tasks=None):
+    """Build an AsyncMock ClickUpClient with sensible defaults."""
+    c = AsyncMock()
+    c.validate_auth.return_value = (
+        validate_ok,
+        "ok" if validate_ok else "bad token",
+        _named(id=1, username="evan", email="evan@example.com") if validate_ok else None,
+    )
+    c.get_teams.return_value = teams or []
+    c.get_spaces.return_value = spaces or []
+    c.get_folders.return_value = folders or []
+    c.get_lists.return_value = []
+    c.get_folderless_lists.return_value = lists or []
+    c.get_tasks.return_value = tasks or []
+    return c
+
+
+def _ctx(client):
+    """Wrap an AsyncMock client in an async-context-manager Mock."""
+    cm = AsyncMock()
+    cm.__aenter__.return_value = client
+    return cm
+
+
+# ---------- token handling ----------------------------------------------------
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_non_interactive_no_token_refuses(mock_client_cls):
+    """--non-interactive without a token (and no env) errors out."""
+    result = runner.invoke(app, ["setup", "run", "--non-interactive"])
+    assert result.exit_code == 2
+    assert "No API token configured" in result.stderr
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_with_token_and_single_workspace_auto_selects(mock_client_cls):
+    """All flags + single team/space/list = no prompts, success."""
+    team = _named(id="T1", name="Acme")
+    space = _named(id="S1", name="Eng")
+    lst = _named(id="L1", name="Sprint", task_count=5)
+    client = _mock_client(teams=[team], spaces=[space], lists=[lst])
+    mock_client_cls.return_value = _ctx(client)
+
+    result = runner.invoke(app, ["setup", "run", "--token", "pk_test", "--non-interactive"])
+    assert result.exit_code == 0, result.output
+    assert "Auto-selected workspace" in result.output
+    assert "Auto-selected space" in result.output
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_with_all_flags_no_prompts(mock_client_cls):
+    """All ID flags supplied -> exact selection, no prompts."""
+    teams = [_named(id="T1", name="A"), _named(id="T2", name="B")]
+    spaces = [_named(id="S1", name="X"), _named(id="S2", name="Y")]
+    lists = [_named(id="L1", name="Sprint", task_count=5)]
+    client = _mock_client(teams=teams, spaces=spaces, lists=lists)
+
+    # First get_spaces returns spaces of chosen team — same mock returns regardless
+    mock_client_cls.return_value = _ctx(client)
+
+    result = runner.invoke(
+        app,
+        [
+            "setup",
+            "run",
+            "--token",
+            "pk_test",
+            "--team-id",
+            "T2",
+            "--space-id",
+            "S2",
+            "--list-id",
+            "L1",
+            "--non-interactive",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "via --team-id" in result.output
+    assert "via --space-id" in result.output
+    assert "via --list-id" in result.output
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_invalid_team_id_errors(mock_client_cls):
+    """--team-id that doesn't match any team exits 2."""
+    teams = [_named(id="T1", name="Real")]
+    client = _mock_client(teams=teams)
+    mock_client_cls.return_value = _ctx(client)
+
+    result = runner.invoke(
+        app,
+        ["setup", "run", "--token", "pk_test", "--team-id", "T999", "--non-interactive"],
+    )
+    assert result.exit_code == 2
+    assert "not found" in result.stderr
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_invalid_space_id_errors(mock_client_cls):
+    """--space-id that doesn't match any space exits 2."""
+    team = _named(id="T1", name="Acme")
+    spaces = [_named(id="S1", name="Real")]
+    client = _mock_client(teams=[team], spaces=spaces)
+    mock_client_cls.return_value = _ctx(client)
+
+    result = runner.invoke(
+        app,
+        ["setup", "run", "--token", "pk_test", "--space-id", "S999", "--non-interactive"],
+    )
+    assert result.exit_code == 2
+    assert "not found" in result.stderr
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_invalid_list_id_errors(mock_client_cls):
+    """--list-id that doesn't match exits 2."""
+    team = _named(id="T1", name="Acme")
+    space = _named(id="S1", name="Eng")
+    lst = _named(id="L1", name="Real", task_count=5)
+    client = _mock_client(teams=[team], spaces=[space], lists=[lst])
+    mock_client_cls.return_value = _ctx(client)
+
+    result = runner.invoke(
+        app,
+        ["setup", "run", "--token", "pk_test", "--list-id", "L999", "--non-interactive"],
+    )
+    assert result.exit_code == 2
+    assert "not found" in result.stderr
+
+
+# ---------- ambiguous selection without flags --------------------------------
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_non_interactive_multiple_teams_refuses(mock_client_cls):
+    """Two teams + --non-interactive without --team-id errors with hint."""
+    teams = [_named(id="T1", name="A"), _named(id="T2", name="B")]
+    client = _mock_client(teams=teams)
+    mock_client_cls.return_value = _ctx(client)
+
+    result = runner.invoke(app, ["setup", "run", "--token", "pk_test", "--non-interactive"])
+    assert result.exit_code == 2
+    assert "--team-id" in result.stderr
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_non_interactive_multiple_spaces_refuses(mock_client_cls):
+    """Multiple spaces + --non-interactive without --space-id errors."""
+    team = _named(id="T1", name="A")
+    spaces = [_named(id="S1", name="X"), _named(id="S2", name="Y")]
+    client = _mock_client(teams=[team], spaces=spaces)
+    mock_client_cls.return_value = _ctx(client)
+
+    result = runner.invoke(
+        app,
+        ["setup", "run", "--token", "pk_test", "--team-id", "T1", "--non-interactive"],
+    )
+    assert result.exit_code == 2
+    assert "--space-id" in result.stderr
+
+
+# ---------- empty workspaces / spaces ----------------------------------------
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_no_workspaces_errors(mock_client_cls):
+    """No workspaces in account exits 1."""
+    client = _mock_client(teams=[])
+    mock_client_cls.return_value = _ctx(client)
+
+    result = runner.invoke(app, ["setup", "run", "--token", "pk_test", "--non-interactive"])
+    assert result.exit_code == 1
+    assert "No workspaces" in result.output
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_no_spaces_errors(mock_client_cls):
+    """No spaces in workspace exits 1."""
+    team = _named(id="T1", name="A")
+    client = _mock_client(teams=[team], spaces=[])
+    mock_client_cls.return_value = _ctx(client)
+
+    result = runner.invoke(app, ["setup", "run", "--token", "pk_test", "--non-interactive"])
+    assert result.exit_code == 1
+    assert "No spaces" in result.output
+
+
+@patch("clickup.cli.commands.setup.ClickUpClient")
+def test_setup_no_lists_warns_but_succeeds(mock_client_cls):
+    """No lists in space is a warning, not a hard error."""
+    team = _named(id="T1", name="A")
+    space = _named(id="S1", name="X")
+    client = _mock_client(teams=[team], spaces=[space], lists=[])
+    client.get_folders.return_value = []
+    mock_client_cls.return_value = _ctx(client)
+
+    result = runner.invoke(app, ["setup", "run", "--token", "pk_test", "--non-interactive"])
+    assert result.exit_code == 0
+    assert "No lists found" in result.output

--- a/tests/integration/test_task_coverage.py
+++ b/tests/integration/test_task_coverage.py
@@ -1,0 +1,356 @@
+"""Targeted tests for task command paths not yet covered.
+
+Covers create / update / status / search / export / mine / comments,
+plus a handful of error paths.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+from typer.testing import CliRunner
+
+from clickup.cli.main import app
+from clickup.core.exceptions import ClickUpError
+from clickup.core.models import Comment, Task, Team, User
+
+runner = CliRunner()
+
+
+def _ctx(client):
+    cm = AsyncMock()
+    cm.__aenter__.return_value = client
+    return cm
+
+
+# ---------- create -----------------------------------------------------------
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_create_minimal(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.create_task.return_value = Task(id="t1", name="New", url="https://x")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "create", "New", "--list-id", "L1"])
+    assert result.exit_code == 0
+    assert "Created task" in result.output
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_create_all_fields(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.create_task.return_value = Task(id="t1", name="Full")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        [
+            "task",
+            "create",
+            "Full",
+            "--list-id",
+            "L1",
+            "--description",
+            "desc",
+            "--priority",
+            "2",
+            "--assignee",
+            "u1",
+            "--due-date",
+            "2026-12-01",
+            "--status",
+            "on-deck",
+        ],
+    )
+    assert result.exit_code == 0
+    # Verify all fields made it into the API call
+    call_kwargs = mock_client.create_task.call_args.kwargs
+    assert call_kwargs["name"] == "Full"
+    assert call_kwargs["description"] == "desc"
+    assert call_kwargs["priority"] == 2
+    assert call_kwargs["status"] == "on-deck"
+
+
+def test_task_create_no_list_errors():
+    result = runner.invoke(app, ["task", "create", "X"])
+    assert result.exit_code != 0
+    assert "list" in result.output.lower()
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_create_api_error(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.create_task.side_effect = ClickUpError("rate limited")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "create", "X", "--list-id", "L1"])
+    assert result.exit_code == 1
+    assert "rate limited" in result.stderr
+
+
+# ---------- update -----------------------------------------------------------
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_update_name_and_description(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.update_task.return_value = Task(id="t1", name="Renamed")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "update", "t1", "--name", "Renamed", "--description", "d"])
+    assert result.exit_code == 0
+    assert "Updated task" in result.output
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_update_clear_description_with_empty_string(mock_get_client):
+    """`--description ''` should clear the field — the modify-if-passed contract."""
+    mock_client = AsyncMock()
+    mock_client.update_task.return_value = Task(id="t1", name="X")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "update", "t1", "--description", ""])
+    assert result.exit_code == 0
+    call_kwargs = mock_client.update_task.call_args.kwargs
+    assert call_kwargs["description"] == ""
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_update_no_fields_warns(mock_get_client):
+    mock_client = AsyncMock()
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "update", "t1"])
+    assert result.exit_code == 0
+    assert "No updates specified" in result.stderr
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_update_archived(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.update_task.return_value = Task(id="t1", name="X")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "update", "t1", "--archived"])
+    assert result.exit_code == 0
+    assert mock_client.update_task.call_args.kwargs["archived"] is True
+
+
+# ---------- status -----------------------------------------------------------
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_status_change(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.update_task.return_value = Task(id="t1", name="X")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "status", "--task-id", "t1", "--status", "done"])
+    assert result.exit_code == 0
+    assert "Updated task status" in result.output
+
+
+def test_task_status_missing_id_errors():
+    result = runner.invoke(app, ["task", "status", "--status", "done"])
+    assert result.exit_code != 0
+    assert "Task ID" in result.stderr
+
+
+def test_task_status_missing_status_errors():
+    result = runner.invoke(app, ["task", "status", "--task-id", "t1"])
+    assert result.exit_code != 0
+    assert "Status" in result.stderr
+
+
+# ---------- search -----------------------------------------------------------
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_search_finds_results(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.search_tasks.return_value = [Task(id="t1", name="Match")]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "search", "--query", "foo", "--workspace-id", "W1"])
+    assert result.exit_code == 0
+    assert "Match" in result.output
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_search_empty(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.search_tasks.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "search", "--query", "foo", "--workspace-id", "W1"])
+    assert result.exit_code == 0
+    assert "No tasks found" in result.stderr
+
+
+def test_task_search_no_query_errors():
+    result = runner.invoke(app, ["task", "search", "--workspace-id", "W1"])
+    assert result.exit_code != 0
+    assert "query" in result.stderr.lower()
+
+
+def test_task_search_no_workspace_errors():
+    result = runner.invoke(app, ["task", "search", "--query", "foo"])
+    assert result.exit_code != 0
+    assert "workspace" in result.stderr.lower()
+
+
+# ---------- export -----------------------------------------------------------
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_export_json(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_tasks.return_value = [Task(id="t1", name="One")]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        result = runner.invoke(
+            app,
+            ["task", "export", "--list-id", "L1", "--output", f.name, "--format", "json"],
+        )
+    assert result.exit_code == 0
+    data = json.loads(Path(f.name).read_text())
+    assert data[0]["name"] == "One"
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_export_csv(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_tasks.return_value = [Task(id="t1", name="One")]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        result = runner.invoke(
+            app,
+            ["task", "export", "--list-id", "L1", "--output", f.name, "--format", "csv"],
+        )
+    assert result.exit_code == 0
+    content = Path(f.name).read_text()
+    assert "id,name,status" in content
+    assert "One" in content
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_export_unsupported_format_errors(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_tasks.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    with tempfile.NamedTemporaryFile(suffix=".xml") as f:
+        result = runner.invoke(
+            app,
+            ["task", "export", "--list-id", "L1", "--output", f.name, "--format", "xml"],
+        )
+    assert result.exit_code != 0
+    assert "Unsupported" in result.stderr
+
+
+def test_task_export_no_list_errors():
+    result = runner.invoke(app, ["task", "export"])
+    assert result.exit_code != 0
+
+
+# ---------- mine -------------------------------------------------------------
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_mine_with_explicit_workspace(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_user.return_value = User(id=42, username="evan", email="e@x.com")
+    mock_client.search_tasks.return_value = [Task(id="t1", name="Mine")]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "mine", "--workspace-id", "W1"])
+    assert result.exit_code == 0
+    assert "Mine" in result.output
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_mine_auto_detects_single_workspace(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_user.return_value = User(id=42, username="evan", email="e@x.com")
+    mock_client.get_teams.return_value = [Team(id="W1", name="Solo", color="#000", members=[])]
+    mock_client.search_tasks.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "mine"])
+    assert result.exit_code == 0
+    assert "No tasks assigned" in result.stderr
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_mine_no_workspaces_errors(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_user.return_value = User(id=42, username="evan", email="e@x.com")
+    mock_client.get_teams.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "mine"])
+    assert result.exit_code != 0
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_mine_multiple_workspaces_errors(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_user.return_value = User(id=42, username="evan", email="e@x.com")
+    mock_client.get_teams.return_value = [
+        Team(id="W1", name="A", color="#000", members=[]),
+        Team(id="W2", name="B", color="#000", members=[]),
+    ]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "mine"])
+    assert result.exit_code != 0
+
+
+# ---------- comments ---------------------------------------------------------
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_comments_list(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_task_comments.return_value = [
+        Comment(
+            id="c1",
+            comment=[{"text": "hi"}],
+            comment_text="hi",
+            user=User(id=1, username="u", email="u@x.com"),
+            date="1700000000000",
+        )
+    ]
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "comments", "list", "t1"])
+    assert result.exit_code == 0
+    assert "hi" in result.output
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_comments_list_empty(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.get_task_comments.return_value = []
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "comments", "list", "t1"])
+    assert result.exit_code == 0
+    assert "No comments" in result.stderr
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_comments_add(mock_get_client):
+    mock_client = AsyncMock()
+    mock_client.create_comment.return_value = Mock(id="c1")
+    mock_get_client.return_value = _ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "comments", "add", "t1", "hello"])
+    assert result.exit_code == 0
+    assert "Comment added" in result.output

--- a/tests/integration/test_workspace_commands.py
+++ b/tests/integration/test_workspace_commands.py
@@ -108,9 +108,9 @@ def test_workspace_list(mock_get_client, sample_teams):
     result = runner.invoke(app, ["workspace", "list"])
 
     assert result.exit_code == 0
-    assert "Engineering Team" in result.stdout
-    assert "Marketing Team" in result.stdout
-    assert "Sales Team" in result.stdout
+    assert "Engineering Team" in result.output
+    assert "Marketing Team" in result.output
+    assert "Sales Team" in result.output
 
 
 @patch("clickup.cli.commands.workspace.get_client")
@@ -123,9 +123,9 @@ def test_workspace_spaces(mock_get_client, sample_spaces):
     result = runner.invoke(app, ["workspace", "spaces", "--workspace-id", "team123"])
 
     assert result.exit_code == 0
-    assert "Development" in result.stdout
-    assert "QA Testing" in result.stdout
-    assert "Documentation" in result.stdout
+    assert "Development" in result.output
+    assert "QA Testing" in result.output
+    assert "Documentation" in result.output
 
 
 @patch("clickup.cli.commands.workspace.get_client")
@@ -138,9 +138,9 @@ def test_workspace_folders(mock_get_client, sample_folders):
     result = runner.invoke(app, ["workspace", "folders", "--space-id", "space123"])
 
     assert result.exit_code == 0
-    assert "Backend" in result.stdout
-    assert "Frontend" in result.stdout
-    assert "DevOps" in result.stdout
+    assert "Backend" in result.output
+    assert "Frontend" in result.output
+    assert "DevOps" in result.output
 
 
 @patch("clickup.cli.commands.workspace.get_client")
@@ -153,26 +153,26 @@ def test_workspace_members(mock_get_client, sample_members):
     result = runner.invoke(app, ["workspace", "members", "--workspace-id", "team123"])
 
     assert result.exit_code == 0
-    assert "john.doe" in result.stdout
-    assert "jane.smith" in result.stdout
-    assert "bob.wilson" in result.stdout
-    assert "owner" in result.stdout
-    assert "admin" in result.stdout
-    assert "member" in result.stdout
+    assert "john.doe" in result.output
+    assert "jane.smith" in result.output
+    assert "bob.wilson" in result.output
+    assert "owner" in result.output
+    assert "admin" in result.output
+    assert "member" in result.output
 
 
 def test_workspace_spaces_missing_team_id():
     """Test spaces command without team ID."""
     result = runner.invoke(app, ["workspace", "spaces"])
     assert result.exit_code != 0
-    assert "workspace" in result.stdout.lower()
+    assert "workspace" in result.output.lower()
 
 
 def test_workspace_folders_missing_space_id():
     """Test folders command without space ID."""
     result = runner.invoke(app, ["workspace", "folders"])
     assert result.exit_code != 0
-    assert "space-id" in result.stdout
+    assert "space-id" in result.output
 
 
 def test_workspace_members_missing_team_id():

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -1,0 +1,541 @@
+"""Direct tests for clickup/cli/output.py renderers.
+
+Each renderer is exercised in both table and JSON modes; JSON output is parsed
+to confirm shape. These tests pin the output contract that agents depend on.
+"""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+
+import pytest
+
+from clickup.cli import output
+from clickup.cli.output import (
+    FormatChoice,
+    format_timestamp,
+    get_format,
+    render_comments,
+    render_error,
+    render_folders,
+    render_hierarchy,
+    render_kv,
+    render_list,
+    render_lists,
+    render_message,
+    render_space,
+    render_spaces,
+    render_task,
+    render_tasks,
+    render_team,
+    render_teams,
+    render_user,
+    render_users,
+    set_format,
+)
+from clickup.core.models import (
+    Assignee,
+    Comment,
+    Folder,
+    PriorityInfo,
+    Space,
+    StatusInfo,
+    Task,
+    Team,
+    User,
+)
+from clickup.core.models import (
+    List as ClickUpList,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_format():
+    """Each test starts in table mode."""
+    set_format(FormatChoice.table)
+    yield
+    set_format(FormatChoice.table)
+
+
+@pytest.fixture
+def capture_console(monkeypatch):
+    """Replace the module-level rich Console with one writing to a StringIO."""
+    from rich.console import Console as RConsole
+
+    buf = StringIO()
+    monkeypatch.setattr(output, "_console", RConsole(file=buf, force_terminal=False, width=200))
+    return buf
+
+
+@pytest.fixture
+def capture_stderr(monkeypatch, capsys):
+    """Use capsys for stderr (typer.echo writes there)."""
+    return capsys
+
+
+# ---------- helpers ----------------------------------------------------------
+
+
+def _user(**kw):
+    base = {"id": 1, "username": "evan", "email": "evan@example.com", "color": "#fff"}
+    base.update(kw)
+    return User(**base)
+
+
+def _team(**kw):
+    base = {"id": "T1", "name": "Acme", "color": "#000", "members": []}
+    base.update(kw)
+    return Team(**base)
+
+
+def _space(**kw):
+    base = {"id": "S1", "name": "Engineering", "private": False, "statuses": [], "multiple_assignees": True}
+    base.update(kw)
+    return Space(**base)
+
+
+def _list(**kw):
+    base = {"id": "L1", "name": "Sprint 42", "task_count": 7}
+    base.update(kw)
+    return ClickUpList(**base)
+
+
+def _folder(**kw):
+    from clickup.core.models import SpaceRef
+
+    base = {
+        "id": "F1",
+        "name": "Backend",
+        "orderindex": 0,
+        "override_statuses": False,
+        "hidden": False,
+        "space": SpaceRef(id="S1", name="Eng"),
+        "task_count": "12",
+    }
+    base.update(kw)
+    return Folder(**base)
+
+
+def _task(**kw):
+    base = {
+        "id": "task42",
+        "name": "Ship the thing",
+        "description": "A description",
+        "status": StatusInfo(status="open"),
+        "priority": PriorityInfo(priority="2", id="2"),
+        "assignees": [Assignee(id=1, username="evan")],
+        "date_created": "1700000000000",
+        "date_updated": "1700100000000",
+        "due_date": "1700500000000",
+    }
+    base.update(kw)
+    return Task(**base)
+
+
+def _comment(**kw):
+    base = {
+        "id": "C1",
+        "comment": [{"text": "looks good"}],
+        "comment_text": "looks good",
+        "user": _user(),
+        "date": "1700000000000",
+    }
+    base.update(kw)
+    return Comment(**base)
+
+
+# ---------- format state ------------------------------------------------------
+
+
+def test_format_default_is_table():
+    set_format(FormatChoice.table)
+    assert get_format() == "table"
+
+
+def test_set_format_string_and_enum():
+    set_format("json")
+    assert get_format() == "json"
+    set_format(FormatChoice.table)
+    assert get_format() == "table"
+
+
+# ---------- format_timestamp --------------------------------------------------
+
+
+def test_format_timestamp_human():
+    out = format_timestamp("1700000000000")
+    assert out.startswith("20")  # yyyy-mm-dd
+    assert "-" in out
+
+
+def test_format_timestamp_iso_for_json():
+    out = format_timestamp("1700000000000", for_json=True)
+    assert out.endswith("Z")
+    assert "T" in out
+
+
+def test_format_timestamp_empty():
+    assert format_timestamp(None) == ""
+    assert format_timestamp("") == ""
+
+
+def test_format_timestamp_unparseable_passes_through():
+    assert format_timestamp("not-a-number") == "not-a-number"
+
+
+# ---------- render_user -------------------------------------------------------
+
+
+def test_render_user_table(capture_console):
+    render_user(_user())
+    out = capture_console.getvalue()
+    assert "evan" in out
+    assert "evan@example.com" in out
+
+
+def test_render_user_json(capsys):
+    set_format("json")
+    render_user(_user(role=2))
+    captured = capsys.readouterr().out
+    data = json.loads(captured)
+    assert data["username"] == "evan"
+    assert data["role"] == 2
+
+
+# ---------- render_team(s) ----------------------------------------------------
+
+
+def test_render_team_table(capture_console):
+    render_team(_team())
+    assert "Acme" in capture_console.getvalue()
+
+
+def test_render_team_json(capsys):
+    set_format("json")
+    render_team(_team())
+    data = json.loads(capsys.readouterr().out)
+    assert data["name"] == "Acme"
+
+
+def test_render_teams_collection_shape(capsys):
+    set_format("json")
+    render_teams([_team(), _team(id="T2", name="Other")])
+    data = json.loads(capsys.readouterr().out)
+    assert data["count"] == 2
+    assert {t["name"] for t in data["data"]} == {"Acme", "Other"}
+
+
+def test_render_teams_table(capture_console):
+    render_teams([_team(), _team(id="T2", name="Other")])
+    out = capture_console.getvalue()
+    assert "Acme" in out
+    assert "Other" in out
+
+
+# ---------- render_space(s) ---------------------------------------------------
+
+
+def test_render_space_table(capture_console):
+    render_space(_space())
+    assert "Engineering" in capture_console.getvalue()
+
+
+def test_render_space_json(capsys):
+    set_format("json")
+    render_space(_space(private=True))
+    data = json.loads(capsys.readouterr().out)
+    assert data["private"] is True
+
+
+def test_render_spaces_collection_shape(capsys):
+    set_format("json")
+    render_spaces([_space()])
+    data = json.loads(capsys.readouterr().out)
+    assert data["count"] == 1
+    assert data["data"][0]["name"] == "Engineering"
+
+
+def test_render_spaces_table(capture_console):
+    render_spaces([_space()])
+    assert "Engineering" in capture_console.getvalue()
+
+
+# ---------- render_list(s) ----------------------------------------------------
+
+
+def test_render_list_table(capture_console):
+    render_list(_list(due_date="1700000000000"))
+    out = capture_console.getvalue()
+    assert "Sprint 42" in out
+    assert "7" in out  # task_count
+
+
+def test_render_list_json(capsys):
+    set_format("json")
+    render_list(_list())
+    data = json.loads(capsys.readouterr().out)
+    assert data["task_count"] == 7
+
+
+def test_render_lists_collection_shape(capsys):
+    set_format("json")
+    render_lists([_list(), _list(id="L2", name="Sprint 43")])
+    data = json.loads(capsys.readouterr().out)
+    assert data["count"] == 2
+
+
+def test_render_lists_table(capture_console):
+    render_lists([_list()])
+    assert "Sprint 42" in capture_console.getvalue()
+
+
+# ---------- render_folders ----------------------------------------------------
+
+
+def test_render_folders_table(capture_console):
+    render_folders([_folder()])
+    out = capture_console.getvalue()
+    assert "Backend" in out
+    assert "12" in out
+
+
+def test_render_folders_json(capsys):
+    set_format("json")
+    render_folders([_folder(hidden=True)])
+    data = json.loads(capsys.readouterr().out)
+    assert data["count"] == 1
+    assert data["data"][0]["hidden"] is True
+
+
+def test_render_folders_table_hidden(capture_console):
+    render_folders([_folder(hidden=True)])
+    assert "Yes" in capture_console.getvalue()
+
+
+# ---------- render_users ------------------------------------------------------
+
+
+def test_render_users_table(capture_console):
+    render_users([_user(), _user(id=2, username="other", email="other@x.com")])
+    out = capture_console.getvalue()
+    assert "evan" in out
+    assert "other" in out
+
+
+def test_render_users_json(capsys):
+    set_format("json")
+    render_users([_user(role=1)])
+    data = json.loads(capsys.readouterr().out)
+    assert data["count"] == 1
+    assert data["data"][0]["role"] == 1
+
+
+def test_render_users_custom_title(capture_console):
+    render_users([_user()], title="Custom Title")
+    assert "Custom Title" in capture_console.getvalue()
+
+
+def test_render_users_handles_no_role(capture_console):
+    render_users([_user(role=None)])
+    assert "None" in capture_console.getvalue()
+
+
+# ---------- render_task(s) ----------------------------------------------------
+
+
+def test_render_task_table(capture_console):
+    render_task(_task())
+    out = capture_console.getvalue()
+    assert "Ship the thing" in out
+    assert "evan" in out
+
+
+def test_render_task_table_no_status(capture_console):
+    render_task(_task(status=None, priority=None, assignees=[], due_date=None, description=None))
+    out = capture_console.getvalue()
+    assert "Unknown" in out  # status fallback
+    assert "Unassigned" in out
+
+
+def test_render_task_json(capsys):
+    set_format("json")
+    render_task(_task())
+    data = json.loads(capsys.readouterr().out)
+    assert data["name"] == "Ship the thing"
+    assert "priority_label" in data  # dual-display
+    assert data["date_created"].endswith("Z")  # ISO 8601
+
+
+def test_render_tasks_table(capture_console):
+    render_tasks([_task(), _task(id="task43", name="Other")])
+    out = capture_console.getvalue()
+    assert "Ship the thing" in out
+    assert "Other" in out
+
+
+def test_render_tasks_json(capsys):
+    set_format("json")
+    render_tasks([_task()])
+    data = json.loads(capsys.readouterr().out)
+    assert data["count"] == 1
+    assert data["data"][0]["name"] == "Ship the thing"
+
+
+# ---------- render_comments ---------------------------------------------------
+
+
+def test_render_comments_table(capture_console):
+    render_comments([_comment()])
+    out = capture_console.getvalue()
+    assert "looks good" in out
+
+
+def test_render_comments_json(capsys):
+    set_format("json")
+    render_comments([_comment()])
+    data = json.loads(capsys.readouterr().out)
+    assert data["count"] == 1
+    assert data["data"][0]["comment_text"] == "looks good"
+
+
+def test_render_comments_empty(capture_console):
+    render_comments([])
+    # Should still render, no crash
+    assert capture_console.getvalue() is not None
+
+
+# ---------- render_hierarchy --------------------------------------------------
+
+
+@pytest.fixture
+def hierarchy_data():
+    return {
+        "workspaces": [
+            {
+                "id": "T1",
+                "name": "Acme",
+                "spaces": [
+                    {
+                        "id": "S1",
+                        "name": "Eng",
+                        "folders": [
+                            {
+                                "id": "F1",
+                                "name": "Backend",
+                                "lists": [{"id": "L1", "name": "Sprint", "task_count": 5}],
+                            }
+                        ],
+                        "folderless_lists": [{"id": "L9", "name": "Loose", "task_count": 1}],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_render_hierarchy_table(capture_console, hierarchy_data):
+    render_hierarchy(hierarchy_data)
+    out = capture_console.getvalue()
+    assert "Acme" in out
+    assert "Eng" in out
+    assert "Backend" in out
+    assert "Sprint" in out
+    assert "Loose" in out
+
+
+def test_render_hierarchy_json(capsys, hierarchy_data):
+    set_format("json")
+    render_hierarchy(hierarchy_data)
+    data = json.loads(capsys.readouterr().out)
+    assert data["workspaces"][0]["name"] == "Acme"
+
+
+def test_render_hierarchy_empty(capture_console):
+    render_hierarchy({"workspaces": []})
+    # Should render the root tree node only
+    assert "ClickUp Hierarchy" in capture_console.getvalue()
+
+
+# ---------- render_kv ---------------------------------------------------------
+
+
+def test_render_kv_table(capture_console):
+    render_kv({"foo": "bar", "n": 42}, title="Stats")
+    out = capture_console.getvalue()
+    assert "foo" in out
+    assert "bar" in out
+    assert "42" in out
+
+
+def test_render_kv_json(capsys):
+    set_format("json")
+    render_kv({"foo": "bar"}, title="Stats")
+    data = json.loads(capsys.readouterr().out)
+    assert data["foo"] == "bar"
+
+
+# ---------- render_message ----------------------------------------------------
+
+
+def test_render_message_info_to_stdout(capsys):
+    render_message("hello", "info")
+    captured = capsys.readouterr()
+    assert "hello" in captured.out  # stdout for non-error levels (rich console)
+    assert captured.err == ""
+
+
+def test_render_message_warn_to_stderr(capsys):
+    render_message("careful", "warn")
+    captured = capsys.readouterr()
+    assert "careful" in captured.err
+
+
+def test_render_message_error_to_stderr(capsys):
+    render_message("oops", "error")
+    captured = capsys.readouterr()
+    assert "oops" in captured.err
+
+
+def test_render_message_json_info_to_stdout(capsys):
+    set_format("json")
+    render_message("hi", "info")
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data == {"message": "hi", "level": "info"}
+    assert captured.err == ""
+
+
+def test_render_message_json_warn_to_stderr(capsys):
+    set_format("json")
+    render_message("warn-msg", "warn")
+    captured = capsys.readouterr()
+    data = json.loads(captured.err)
+    assert data == {"message": "warn-msg", "level": "warn"}
+
+
+# ---------- render_error ------------------------------------------------------
+
+
+def test_render_error_to_stderr(capsys):
+    render_error("boom")
+    captured = capsys.readouterr()
+    assert "boom" in captured.err
+    assert captured.out == ""
+
+
+def test_render_error_json(capsys):
+    set_format("json")
+    render_error("boom")
+    captured = capsys.readouterr()
+    data = json.loads(captured.err)
+    assert data == {"error": "boom"}
+    assert captured.out == ""
+
+
+def test_render_error_escapes_markup(capsys):
+    """Rich-bracket text in user data must be escaped, not interpreted."""
+    render_error("[bold]not a tag[/bold]")
+    captured = capsys.readouterr()
+    # The escaped form should appear; either way, no markup parsing crash.
+    assert "[bold]not a tag" in captured.err or "not a tag" in captured.err


### PR DESCRIPTION
Closes #8 — Increase Test Coverage to >80%
Closes #15 — Next batch: item 3 (renderer migration) — items 2 & 4 shipped in #16; items 1 & 5 remain open

## Summary

Three follow-ups from #16's PR-body checklist, in one PR:

1. **Strip dead spinner-shim call sites** — 25 `with Progress(...): progress.add_task(...)` blocks across task / list / bulk / discover / templates / workspace removed. `clickup/cli/utils.py` shim helpers deleted (no remaining callers).
2. **Migrate legacy commands to format-aware renderers** (#15 item 3) — `workspace list/spaces/folders/members` and `discover hierarchy` now route through new/existing helpers in `clickup/cli/output.py`. `cup --format json` emits the contract shape (`{"data":[...],"count":N}` for collections; nested dict for the hierarchy).
3. **Test coverage 67% → 90%** (#8) — 7 new test files, 186 new tests, parsing JSON output to pin the contract.

Net diff: +3,259 / −703 across 19 files. Almost half the additions are tests.

## What changed

### Spinner cleanup
- 25 `with Progress(...)` blocks removed; method calls (`progress.add_task / update / advance`) cleaned up too.
- `clickup/cli/utils.py` reduced from 109 lines to 52 (deleted `_NullProgress` + 5 shim functions). The only remaining export is `run_async`.

### Renderer migration (issue #15 item 3)
- New renderers in `clickup/cli/output.py`:
  - `render_folders(folders)` — folder list table + JSON
  - `render_users(users, *, title=)` — used by `workspace members`
  - `render_hierarchy(data: dict)` — workspace → space → folder → list tree (table mode renders a Rich Tree; JSON mode emits the dict)
- Migrated:
  - `workspace list` → `render_teams`
  - `workspace spaces` → `render_spaces`
  - `workspace folders` → `render_folders`
  - `workspace members` → `render_users`
  - `discover hierarchy` → `render_hierarchy`
- All command flows preserve existing behavior in table mode and now correctly emit JSON when `--format json` is set globally.

### Test coverage 67% → 90%
| File | Before | After | Delta |
|---|---|---|---|
| `output.py` | 40% | **99%** | +59 |
| `setup.py` | 8% | **86%** | +78 |
| `config.py` | 61% | **96%** | +35 |
| `task.py` | 56% | **90%** | +34 |
| `main.py` | 56% | **86%** | +30 |
| `discover.py` | 50% | **85%** | +35 |
| `bulk.py` | 75% | **83%** | +8 |
| `list.py` | 85% | **91%** | +6 |
| `templates.py` | 60% | **76%** | +16 |
| **TOTAL** | **67%** | **90%** | **+23** |

New test files:
- `tests/unit/test_renderers.py` — 48 tests pinning every renderer in both modes
- `tests/integration/test_json_format.py` — JSON contract for migrated commands (#15 acceptance: \"each command runs in both modes and JSON parses\")
- `tests/integration/test_setup_wizard.py` — non-interactive wizard flows
- `tests/integration/test_task_coverage.py` — task create/update/status/search/export/mine/comments
- `tests/integration/test_command_coverage.py` — templates / discover ids+path / list / config / smoke
- `tests/integration/test_main_coverage.py` — `status` in valid / invalid / auto-detect / JSON modes
- `tests/integration/test_more_coverage.py` — error paths and edge cases
- `tests/integration/test_final_coverage.py` — interactive-prompt setup paths via `patch(\"typer.prompt\")`, plus templates with custom files / `--variables` / `--template-file`

### Incidental bug fix: format state bleed
`_current_format` in `output.py` persisted across `runner.invoke()` calls because the root callback only updated it when `--format` was passed. Now resets to `table` if the flag is omitted, so test runs and long-running embeddings of the CLI no longer carry stale state forward.

## Out of scope (still open)

#15 items 1, 4, 5 are not in this PR:
- 1. `.env` discovery for non-project cwd
- 4. `whoami` top-level alias
- 5. Pollution-tolerant config load + `clickup config doctor`

## Test plan

- [x] `uv run pytest tests/unit tests/integration` → **377 passed, 1 skipped**
- [x] `--cov` report shows TOTAL 90% (2,446 stmts, 239 missing)
- [x] `ruff check` + `ruff format` clean on the diff (3 pre-existing UP042 errors in `output.py`/`models.py` are unchanged baseline)
- [ ] Live `cli-agent-eval` skill — recommend running before merge to confirm no regression vs the post-#16 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)