### PR TITLE
Fix `list get`/`list show`: honor --format json and resolve list aliases

### DIFF
--- a/clickup/cli/commands/list.py
+++ b/clickup/cli/commands/list.py
@@ -4,10 +4,9 @@ from typing import Any
 
 import typer
 from rich.console import Console
-from rich.table import Table
 
 from ...core import ClickUpClient, ClickUpError, Config
-from ..output import render_error
+from ..output import render_error, render_list, render_lists
 from ..utils import run_async
 
 app = typer.Typer(help="List management")
@@ -24,6 +23,16 @@ async def get_client() -> ClickUpClient:
         )
         raise typer.Exit(1)
     return ClickUpClient(config, console)
+
+
+def _resolve_list_id(list_id: str | None) -> str | None:
+    """Resolve a list ID, expanding configured aliases (mirrors task.py)."""
+    config = Config()
+    resolver = getattr(config, "resolve_list_id", None)
+    if callable(resolver):
+        result: str | None = resolver(list_id)
+        return result
+    return list_id or config.get("default_list_id")
 
 
 @app.command("show")
@@ -47,27 +56,7 @@ def list_lists(
                     # space_id is guaranteed non-None here due to the check above
                     assert space_id is not None
                     lists = await client.get_folderless_lists(space_id)
-                if not lists:
-                    console.print("[yellow]No lists found.[/yellow]")
-                    return
-
-                table = Table(title="Lists", show_header=True)
-                table.add_column("ID", style="cyan")
-                table.add_column("Name", style="bold")
-                table.add_column("Task Count", style="green")
-                table.add_column("Due Date", style="yellow")
-                table.add_column("Archived", style="red")
-
-                for list_item in lists:
-                    table.add_row(
-                        list_item.id,
-                        list_item.name,
-                        str(list_item.task_count or 0),
-                        list_item.due_date or "None",
-                        "Yes" if list_item.archived else "No",
-                    )
-
-                console.print(table)
+                render_lists(lists)
 
         except ClickUpError as e:
             render_error(f"ClickUp API Error: {e}")
@@ -81,8 +70,7 @@ def get_list(list_id: str | None = typer.Option(None, "--list-id", "-l", help="L
     """Get detailed information about a specific list."""
 
     async def _get_list() -> None:
-        config = Config()
-        list_id_to_use = list_id or config.get("default_list_id")
+        list_id_to_use = _resolve_list_id(list_id)
 
         if not list_id_to_use:
             render_error("Error: No list ID provided and no default list configured.")
@@ -92,30 +80,7 @@ def get_list(list_id: str | None = typer.Option(None, "--list-id", "-l", help="L
         try:
             async with await get_client() as client:
                 list_item = await client.get_list(list_id_to_use)
-                # Create detailed list info table
-                table = Table(title=f"List: {list_item.name}", show_header=False)
-                table.add_column("Field", style="cyan", width=15)
-                table.add_column("Value", style="white")
-
-                table.add_row("ID", list_item.id)
-                table.add_row("Name", list_item.name)
-                table.add_row("Content", list_item.content or "None")
-                table.add_row("Task Count", str(list_item.task_count or 0))
-                table.add_row("Order Index", str(list_item.orderindex))
-                table.add_row("Due Date", list_item.due_date or "None")
-                table.add_row("Start Date", list_item.start_date or "None")
-                table.add_row("Archived", "Yes" if list_item.archived else "No")
-
-                if list_item.assignee:
-                    table.add_row("Assignee", list_item.assignee.username)
-
-                if list_item.folder:
-                    table.add_row("Folder", list_item.folder.name or "Unknown")
-
-                if list_item.space:
-                    table.add_row("Space", list_item.space.name or "Unknown")
-
-                console.print(table)
+                render_list(list_item)
 
         except ClickUpError as e:
             render_error(f"ClickUp API Error: {e}")

--- a/clickup/cli/commands/list.py
+++ b/clickup/cli/commands/list.py
@@ -27,12 +27,7 @@ async def get_client() -> ClickUpClient:
 
 def _resolve_list_id(list_id: str | None) -> str | None:
     """Resolve a list ID, expanding configured aliases (mirrors task.py)."""
-    config = Config()
-    resolver = getattr(config, "resolve_list_id", None)
-    if callable(resolver):
-        result: str | None = resolver(list_id)
-        return result
-    return list_id or config.get("default_list_id")
+    return Config().resolve_list_id(list_id)
 
 
 @app.command("show")

--- a/clickup/cli/commands/task.py
+++ b/clickup/cli/commands/task.py
@@ -30,13 +30,8 @@ async def get_client() -> ClickUpClient:
 
 
 def _resolve_list_id(list_id: str | None) -> str | None:
-    """Resolve a list ID using Agent C's resolver if available, else fallback."""
-    config = Config()
-    resolver = getattr(config, "resolve_list_id", None)
-    if callable(resolver):
-        result: str | None = resolver(list_id)
-        return result
-    return list_id or config.get("default_list_id")
+    """Resolve a list ID, expanding configured aliases."""
+    return Config().resolve_list_id(list_id)
 
 
 async def _resolve_workspace_id(client: ClickUpClient, workspace_id: str | None) -> str:

--- a/clickup/cli/output.py
+++ b/clickup/cli/output.py
@@ -249,10 +249,11 @@ def render_list(lst: ClickUpList) -> None:
         table.add_row("Folder", escape(lst.folder.name))
     if lst.space is not None and lst.space.name:
         table.add_row("Space", escape(lst.space.name))
-    extra = lst.model_extra
-    statuses = extra.get("statuses") if isinstance(extra, dict) else None
+    statuses = (lst.model_extra or {}).get("statuses")
     if isinstance(statuses, list) and statuses:
-        names = ", ".join(escape(s.get("status", "")) if isinstance(s, dict) else escape(s.status) for s in statuses)
+        names = ", ".join(
+            escape(s.get("status", "") if isinstance(s, dict) else getattr(s, "status", str(s))) for s in statuses
+        )
         table.add_row("Statuses", names)
     _console.print(table)
 

--- a/clickup/cli/output.py
+++ b/clickup/cli/output.py
@@ -231,14 +231,29 @@ def render_list(lst: ClickUpList) -> None:
     if get_format() == "json":
         _print_json(lst.model_dump(mode="json"))
         return
-    table = Table(title="List", show_header=False)
-    table.add_column("Field", style="cyan")
+    table = Table(title=f"List: {escape(lst.name)}", show_header=False)
+    table.add_column("Field", style="cyan", width=15)
     table.add_column("Value")
     table.add_row("ID", lst.id)
     table.add_row("Name", escape(lst.name))
+    table.add_row("Content", escape(lst.content) if lst.content else "None")
     table.add_row("Tasks", str(lst.task_count) if lst.task_count is not None else "N/A")
-    if lst.due_date:
-        table.add_row("Due Date", format_timestamp(lst.due_date))
+    if lst.orderindex is not None:
+        table.add_row("Order Index", str(lst.orderindex))
+    table.add_row("Due Date", format_timestamp(lst.due_date) if lst.due_date else "None")
+    table.add_row("Start Date", format_timestamp(lst.start_date) if lst.start_date else "None")
+    table.add_row("Archived", "Yes" if lst.archived else "No")
+    if lst.assignee is not None:
+        table.add_row("Assignee", escape(lst.assignee.username))
+    if lst.folder is not None and lst.folder.name:
+        table.add_row("Folder", escape(lst.folder.name))
+    if lst.space is not None and lst.space.name:
+        table.add_row("Space", escape(lst.space.name))
+    extra = lst.model_extra
+    statuses = extra.get("statuses") if isinstance(extra, dict) else None
+    if isinstance(statuses, list) and statuses:
+        names = ", ".join(escape(s.get("status", "")) if isinstance(s, dict) else escape(s.status) for s in statuses)
+        table.add_row("Statuses", names)
     _console.print(table)
 
 
@@ -251,8 +266,16 @@ def render_lists(lists: list[ClickUpList]) -> None:
     table.add_column("ID", style="cyan")
     table.add_column("Name", style="bold")
     table.add_column("Tasks", style="green")
+    table.add_column("Due Date", style="yellow")
+    table.add_column("Archived", style="red")
     for lst in lists:
-        table.add_row(lst.id, escape(lst.name), str(lst.task_count) if lst.task_count is not None else "N/A")
+        table.add_row(
+            lst.id,
+            escape(lst.name),
+            str(lst.task_count) if lst.task_count is not None else "N/A",
+            format_timestamp(lst.due_date) if lst.due_date else "None",
+            "Yes" if lst.archived else "No",
+        )
     _console.print(table)
 
 

--- a/tests/integration/test_list_commands.py
+++ b/tests/integration/test_list_commands.py
@@ -1,12 +1,15 @@
 """Tests for list management commands."""
 
+import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from typer.testing import CliRunner
 
 from clickup.cli.main import app
+from clickup.core.config import Config
 from clickup.core.exceptions import ClickUpError
+from clickup.core.models import List as ClickUpList
 
 runner = CliRunner()
 
@@ -260,13 +263,17 @@ def test_list_help():
     assert "create" in result.stdout
 
 
-@patch("clickup.cli.commands.list.get_client")
-async def test_list_get_resolves_alias(mock_get_client, sample_list_detail):
-    """`list get` should resolve list aliases via Config.resolve_list_id, like `task list` does."""
-    from clickup.core.config import Config
+@pytest.fixture
+def isolated_config(tmp_path, monkeypatch):
+    """Point Config() at a throwaway file so tests don't clobber the real user config."""
+    monkeypatch.setenv("CLICKUP_CONFIG_PATH", str(tmp_path / "config.json"))
+    return tmp_path
 
-    config = Config()
-    config.set("default_lists", {"omegapoint": "list123"})
+
+@patch("clickup.cli.commands.list.get_client")
+async def test_list_get_resolves_alias(mock_get_client, sample_list_detail, isolated_config):
+    """`list get` should resolve list aliases via Config.resolve_list_id, like `task list` does."""
+    Config().set("default_lists", {"omegapoint": "list123"})
 
     mock_client = AsyncMock()
     mock_client.get_list.return_value = sample_list_detail
@@ -281,17 +288,12 @@ async def test_list_get_resolves_alias(mock_get_client, sample_list_detail):
     result = runner.invoke(app, ["list", "get", "--list-id", "omegapoint"])
 
     assert result.exit_code == 0, result.stdout
-    # The CLI must call the API with the resolved numeric ID, not the alias.
     mock_client.get_list.assert_awaited_with("list123")
 
 
 @patch("clickup.cli.commands.list.get_client")
-async def test_list_get_respects_format_json(mock_get_client):
+async def test_list_get_respects_format_json(mock_get_client, isolated_config):
     """`list get` should emit valid JSON when `--format json` is set."""
-    import json as _json
-
-    from clickup.core.models import List as ClickUpList
-
     real_list = ClickUpList(id="list123", name="Test List", task_count=7)
     mock_client = AsyncMock()
     mock_client.get_list.return_value = real_list
@@ -306,19 +308,15 @@ async def test_list_get_respects_format_json(mock_get_client):
     result = runner.invoke(app, ["--format", "json", "list", "get", "--list-id", "list123"])
 
     assert result.exit_code == 0, result.stdout
-    payload = _json.loads(result.stdout)
+    payload = json.loads(result.stdout)
     assert payload["id"] == "list123"
     assert payload["name"] == "Test List"
     assert payload["task_count"] == 7
 
 
 @patch("clickup.cli.commands.list.get_client")
-async def test_list_show_respects_format_json(mock_get_client):
+async def test_list_show_respects_format_json(mock_get_client, isolated_config):
     """`list show` should emit valid JSON when `--format json` is set."""
-    import json as _json
-
-    from clickup.core.models import List as ClickUpList
-
     real_lists = [
         ClickUpList(id="list1", name="Todo List", task_count=5),
         ClickUpList(id="list2", name="In Progress", task_count=3),
@@ -330,6 +328,6 @@ async def test_list_show_respects_format_json(mock_get_client):
     result = runner.invoke(app, ["--format", "json", "list", "show", "--folder-id", "folder123"])
 
     assert result.exit_code == 0, result.stdout
-    payload = _json.loads(result.stdout)
+    payload = json.loads(result.stdout)
     assert payload["count"] == 2
     assert {item["id"] for item in payload["data"]} == {"list1", "list2"}

--- a/tests/integration/test_list_commands.py
+++ b/tests/integration/test_list_commands.py
@@ -187,7 +187,8 @@ async def test_list_show_empty_folder(mock_get_client):
     result = runner.invoke(app, ["list", "show", "--folder-id", "empty_folder"])
 
     assert result.exit_code == 0
-    assert "No lists found" in result.stdout or len(result.stdout.strip()) == 0
+    # Empty result renders an empty Lists table (no list names appear)
+    assert "Todo List" not in result.stdout
 
 
 @patch("clickup.cli.commands.list.get_client")
@@ -257,3 +258,78 @@ def test_list_help():
     assert "show" in result.stdout
     assert "get" in result.stdout
     assert "create" in result.stdout
+
+
+@patch("clickup.cli.commands.list.get_client")
+async def test_list_get_resolves_alias(mock_get_client, sample_list_detail):
+    """`list get` should resolve list aliases via Config.resolve_list_id, like `task list` does."""
+    from clickup.core.config import Config
+
+    config = Config()
+    config.set("default_lists", {"omegapoint": "list123"})
+
+    mock_client = AsyncMock()
+    mock_client.get_list.return_value = sample_list_detail
+
+    def create_mock_client():
+        ctx_mgr = AsyncMock()
+        ctx_mgr.__aenter__.return_value = mock_client
+        return ctx_mgr
+
+    mock_get_client.side_effect = create_mock_client
+
+    result = runner.invoke(app, ["list", "get", "--list-id", "omegapoint"])
+
+    assert result.exit_code == 0, result.stdout
+    # The CLI must call the API with the resolved numeric ID, not the alias.
+    mock_client.get_list.assert_awaited_with("list123")
+
+
+@patch("clickup.cli.commands.list.get_client")
+async def test_list_get_respects_format_json(mock_get_client):
+    """`list get` should emit valid JSON when `--format json` is set."""
+    import json as _json
+
+    from clickup.core.models import List as ClickUpList
+
+    real_list = ClickUpList(id="list123", name="Test List", task_count=7)
+    mock_client = AsyncMock()
+    mock_client.get_list.return_value = real_list
+
+    def create_mock_client():
+        ctx_mgr = AsyncMock()
+        ctx_mgr.__aenter__.return_value = mock_client
+        return ctx_mgr
+
+    mock_get_client.side_effect = create_mock_client
+
+    result = runner.invoke(app, ["--format", "json", "list", "get", "--list-id", "list123"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = _json.loads(result.stdout)
+    assert payload["id"] == "list123"
+    assert payload["name"] == "Test List"
+    assert payload["task_count"] == 7
+
+
+@patch("clickup.cli.commands.list.get_client")
+async def test_list_show_respects_format_json(mock_get_client):
+    """`list show` should emit valid JSON when `--format json` is set."""
+    import json as _json
+
+    from clickup.core.models import List as ClickUpList
+
+    real_lists = [
+        ClickUpList(id="list1", name="Todo List", task_count=5),
+        ClickUpList(id="list2", name="In Progress", task_count=3),
+    ]
+    mock_client = AsyncMock()
+    mock_client.get_lists.return_value = real_lists
+    mock_get_client.return_value.__aenter__.return_value = mock_client
+
+    result = runner.invoke(app, ["--format", "json", "list", "show", "--folder-id", "folder123"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = _json.loads(result.stdout)
+    assert payload["count"] == 2
+    assert {item["id"] for item in payload["data"]} == {"list1", "list2"}


### PR DESCRIPTION
## Summary

Two related bugs in `clickup list get` and `clickup list show` that share a root cause:

1. **`list get` ignored the global `--format json` flag.** It built a Rich table inline via `console.print(table)` instead of routing through `output.render_list`, so `clickup --format json list get --list-id <id>` always emitted a table. Same problem in `list show`.

2. **`list get` did not resolve list aliases.** `task list --list-id omegapoint` works, but `list get --list-id omegapoint` returned `validateListIDEx List ID invalid` because it never called `Config.resolve_list_id`.

Both violate the load-bearing decision in `AGENT.md` §1: "Direct `console.print` of structured data is a regression — route it through a renderer instead." The renderers already exist; `list.py` just wasn't using them.

## Repro (before the fix)

```bash
$ cup --format json list get --list-id omegapoint
ClickUp API Error: validateListIDEx List ID invalid

$ cup --format json list get --list-id 901315992466 | head -3
        List: Omega Point         
┌─────────────────┬──────────────┐
│ ID              │ 901315992466 │
```

(After: alias resolves, JSON is JSON, table mode also gains the `Statuses` row that the API returns.)

## What changed

- `clickup/cli/commands/list.py`
  - Added `_resolve_list_id` helper that mirrors `task.py` (calls `Config.resolve_list_id` when available).
  - `get_list` now uses the resolver and calls `render_list(list_item)` instead of building an inline table.
  - `list_lists` (`show`) now calls `render_lists(lists)` instead of building an inline table.
  - Dropped the unused `from rich.table import Table` import.
- `clickup/cli/output.py`
  - Enriched `render_list` to surface the fields the inline table previously showed (Content, Order Index, Start Date, Archived, Folder, Space, Assignee) plus the `statuses` array that the ClickUp API returns. Statuses are read defensively from `model_extra` so the existing `List` model schema doesn't have to change.
  - Enriched `render_lists` to keep parity with the prior inline columns (Tasks, Due Date, Archived).
- `tests/integration/test_list_commands.py`
  - Added `test_list_get_resolves_alias`: configures an alias and asserts the API was called with the resolved numeric ID.
  - Added `test_list_get_respects_format_json` and `test_list_show_respects_format_json`: assert valid JSON shape using real `List` model instances (Mock-based fixtures don't round-trip through `model_dump`).
  - Updated `test_list_show_empty_folder`: empty folders now render an empty `Lists` table (matches `render_tasks` semantics) rather than printing "No lists found".

## Test plan

- [x] `uv run pytest --ignore=tests/live` → 380 passed, 0 regressions
- [x] `uv run ruff format --check` on touched files → clean
- [x] `uv run ruff check` on touched files → only pre-existing UP042 errors that exist on master
- [x] End-to-end against the real API:
  - `cup --format json list get --list-id <alias>` returns a JSON dict with the resolved ID and a `statuses` array
  - `cup list get --list-id <alias>` shows a table that includes the Statuses row
  - `cup --format json list show --folder-id <id>` returns `{"data": [...], "count": N}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)