### PR TITLE
ci: enforce 90% coverage floor via --cov-fail-under

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ exclude = ["tests/**"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-v --cov=clickup --cov-report=term-missing --ignore=tests/live"
+addopts = "-v --cov=clickup --cov-report=term-missing --cov-fail-under=90 --ignore=tests/live"
 asyncio_mode = "auto"
 markers = [
     "live: marks tests as requiring live ClickUp API access (deselect with '-m \"not live\"')",


### PR DESCRIPTION
## Summary

- PR #17 raised coverage to 90%. Without a hard gate, that floor erodes the first time a contributor lands code without matching tests.
- Wires `--cov-fail-under=90` into pytest's addopts so both `just test` (local) and the GitHub Actions `Run tests with coverage` step fail-fast when total coverage drops below 90%.
- Live tests run with `--no-cov` and are unaffected.

## Heads up

Current coverage is **90.23%** — only 0.23% above the floor. The gate is intentionally tight: it forces tests with new code, but a single PR adding ~6 untested statements will trip it. If that becomes annoying in practice, raising the floor *upward* as coverage climbs is preferable to lowering this one.

## Test plan

- [x] Local: `uv run pytest` passes with `Required test coverage of 90% reached. Total coverage: 90.23%`
- [x] Verified the flag is consumed by pytest-cov (the "Required test coverage..." line is the success indicator)
- [ ] CI: this PR's GitHub Actions run will exercise the gate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)