### PR TITLE
Make JSON the default output format

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -80,7 +80,7 @@ JSON shape:
 
 ### 2. `--format` is a GLOBAL flag, not per-command
 
-Wired on the root Typer callback in `main.py`. Set with `clickup --format json <subcommand> ...`. Per-subcommand `--format` would conflict and confuse agents. The `bulk export-tasks` command's pre-existing `--format` (for output FILE format) is the one exception and is unrelated.
+Wired on the root Typer callback in `main.py`. **JSON is the default** — agents are first-class consumers, so the unflagged path emits structured data. Pass `clickup --format table <subcommand> ...` for human-readable output. Per-subcommand `--format` would conflict and confuse agents. The `bulk export-tasks` command's pre-existing `--format` (for output FILE format) is the one exception and is unrelated.
 
 ### 3. Modify-if-passed update semantics
 

--- a/clickup/cli/main.py
+++ b/clickup/cli/main.py
@@ -24,7 +24,7 @@ app = typer.Typer(
 _FORMAT_OPTION = typer.Option(
     None,
     "--format",
-    help="Output format (table or json)",
+    help="Output format (json or table). Defaults to json; use --format table for human-friendly tables.",
     show_default=False,
 )
 
@@ -37,7 +37,7 @@ def _root_callback(
     # Reset format every invocation so module-level state doesn't bleed across
     # repeated CliRunner.invoke() calls in tests (and across long-running
     # processes that re-enter the CLI).
-    set_format(output_format if output_format is not None else FormatChoice.table)
+    set_format(output_format if output_format is not None else FormatChoice.json)
 
 
 # -- Get started --------------------------------------------------------

--- a/clickup/cli/output.py
+++ b/clickup/cli/output.py
@@ -34,7 +34,7 @@ class FormatChoice(str, Enum):
     json = "json"
 
 
-_current_format: Format = "table"
+_current_format: Format = "json"
 
 _console = Console()
 

--- a/tests/integration/test_discovery_commands.py
+++ b/tests/integration/test_discovery_commands.py
@@ -177,7 +177,7 @@ def test_discover_hierarchy_empty_workspace(mock_get_client):
 
     mock_get_client.side_effect = create_mock_client
 
-    result = runner.invoke(app, ["discover", "hierarchy"])
+    result = runner.invoke(app, ["--format", "table", "discover", "hierarchy"])
 
     assert result.exit_code == 0
     assert "ClickUp Hierarchy" in result.stdout

--- a/tests/integration/test_list_commands.py
+++ b/tests/integration/test_list_commands.py
@@ -76,7 +76,7 @@ async def test_list_show_in_folder(mock_get_client, sample_lists):
     mock_client.get_lists.return_value = sample_lists
     mock_get_client.return_value.__aenter__.return_value = mock_client
 
-    result = runner.invoke(app, ["list", "show", "--folder-id", "folder123"])
+    result = runner.invoke(app, ["--format", "table", "list", "show", "--folder-id", "folder123"])
 
     assert result.exit_code == 0
     assert "Todo List" in result.stdout
@@ -91,7 +91,7 @@ async def test_list_show_in_space(mock_get_client, sample_lists):
     mock_client.get_folderless_lists.return_value = sample_lists
     mock_get_client.return_value.__aenter__.return_value = mock_client
 
-    result = runner.invoke(app, ["list", "show", "--space-id", "space123"])
+    result = runner.invoke(app, ["--format", "table", "list", "show", "--space-id", "space123"])
 
     assert result.exit_code == 0
     assert "Todo List" in result.stdout
@@ -111,7 +111,7 @@ async def test_list_get_details(mock_get_client, sample_list_detail):
 
     mock_get_client.side_effect = create_mock_client
 
-    result = runner.invoke(app, ["list", "get", "--list-id", "list123"])
+    result = runner.invoke(app, ["--format", "table", "list", "get", "--list-id", "list123"])
 
     assert result.exit_code == 0
     assert "Test List" in result.stdout
@@ -331,3 +331,19 @@ async def test_list_show_respects_format_json(mock_get_client, isolated_config):
     payload = json.loads(result.stdout)
     assert payload["count"] == 2
     assert {item["id"] for item in payload["data"]} == {"list1", "list2"}
+
+
+@patch("clickup.cli.commands.list.get_client")
+async def test_list_show_defaults_to_json(mock_get_client, isolated_config):
+    """Without an explicit --format flag, the CLI defaults to JSON."""
+    real_lists = [ClickUpList(id="list1", name="Todo List", task_count=5)]
+    mock_client = AsyncMock()
+    mock_client.get_lists.return_value = real_lists
+    mock_get_client.return_value.__aenter__.return_value = mock_client
+
+    result = runner.invoke(app, ["list", "show", "--folder-id", "folder123"])
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["count"] == 1
+    assert payload["data"][0]["id"] == "list1"

--- a/tests/integration/test_main_coverage.py
+++ b/tests/integration/test_main_coverage.py
@@ -42,7 +42,7 @@ def test_status_no_token():
     """Status without a token reports it cleanly."""
     with tempfile.TemporaryDirectory() as tmpdir:
         with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
-            result = runner.invoke(app, ["status"])
+            result = runner.invoke(app, ["--format", "table", "status"])
             assert result.exit_code == 0
             assert "No API token" in result.output
 
@@ -58,7 +58,7 @@ def test_status_with_valid_token(mock_client_cls):
     with tempfile.TemporaryDirectory() as tmpdir:
         with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
             runner.invoke(app, ["config", "set-token", "pk_test"])
-            result = runner.invoke(app, ["status"])
+            result = runner.invoke(app, ["--format", "table", "status"])
             assert result.exit_code == 0
             assert "evan" in result.output
 
@@ -80,7 +80,7 @@ def test_status_with_full_defaults(mock_client_cls):
             runner.invoke(app, ["config", "set", "default_space_id", "S1"])
             runner.invoke(app, ["config", "set", "default_list_id", "L1"])
 
-            result = runner.invoke(app, ["status"])
+            result = runner.invoke(app, ["--format", "table", "status"])
             assert result.exit_code == 0
             assert "Acme" in result.output
             assert "Eng" in result.output
@@ -115,7 +115,7 @@ def test_status_invalid_token(mock_client_cls):
     with tempfile.TemporaryDirectory() as tmpdir:
         with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
             runner.invoke(app, ["config", "set-token", "pk_bogus"])
-            result = runner.invoke(app, ["status"])
+            result = runner.invoke(app, ["--format", "table", "status"])
             assert result.exit_code == 0
             assert "bad token" in result.output
 
@@ -131,7 +131,7 @@ def test_status_auto_detects_single_workspace(mock_client_cls):
     with tempfile.TemporaryDirectory() as tmpdir:
         with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
             runner.invoke(app, ["config", "set-token", "pk_test"])
-            result = runner.invoke(app, ["status"])
+            result = runner.invoke(app, ["--format", "table", "status"])
             assert result.exit_code == 0
             assert "Solo" in result.output
             assert "auto-detected" in result.output
@@ -150,7 +150,7 @@ def test_status_partial_defaults(mock_client_cls):
         with patch("clickup.core.config.Path.home", return_value=Path(tmpdir)):
             runner.invoke(app, ["config", "set-token", "pk_test"])
             runner.invoke(app, ["config", "set", "default_team_id", "T1"])
-            result = runner.invoke(app, ["status"])
+            result = runner.invoke(app, ["--format", "table", "status"])
             assert result.exit_code == 0
             assert "setup run" in result.output  # hint to finish setup
 

--- a/tests/integration/test_task_commands.py
+++ b/tests/integration/test_task_commands.py
@@ -244,7 +244,18 @@ def test_task_list_with_filters(mock_get_client, sample_tasks):
 
     result = runner.invoke(
         app,
-        ["--format", "table", "task", "list", "--list-id", "list123", "--status", "in progress", "--assignee", "john.doe"],
+        [
+            "--format",
+            "table",
+            "task",
+            "list",
+            "--list-id",
+            "list123",
+            "--status",
+            "in progress",
+            "--assignee",
+            "john.doe",
+        ],
     )
 
     assert result.exit_code == 0
@@ -370,7 +381,10 @@ def test_task_search(mock_get_client, sample_tasks):
 
     mock_get_client.side_effect = create_mock_client
 
-    result = runner.invoke(app, ["--format", "table", "task", "search", "--query", "test", "--workspace-id", "workspace123"])
+    result = runner.invoke(
+        app,
+        ["--format", "table", "task", "search", "--query", "test", "--workspace-id", "workspace123"],
+    )
 
     assert result.exit_code == 0
     assert "Test Task" in result.stdout

--- a/tests/integration/test_task_commands.py
+++ b/tests/integration/test_task_commands.py
@@ -84,7 +84,7 @@ def test_task_list(mock_get_client, sample_tasks):
 
     mock_get_client.side_effect = create_mock_client
 
-    result = runner.invoke(app, ["task", "list", "--list-id", "list123"])
+    result = runner.invoke(app, ["--format", "table", "task", "list", "--list-id", "list123"])
 
     assert result.exit_code == 0
     assert "Test Task 1" in result.stdout
@@ -107,7 +107,7 @@ def test_task_get(mock_get_client, sample_task_detail):
 
     mock_get_client.side_effect = create_mock_client
 
-    result = runner.invoke(app, ["task", "get", "task123"])
+    result = runner.invoke(app, ["--format", "table", "task", "get", "task123"])
 
     assert result.exit_code == 0
     assert "Detailed Task" in result.stdout
@@ -243,7 +243,8 @@ def test_task_list_with_filters(mock_get_client, sample_tasks):
     mock_get_client.side_effect = create_mock_client
 
     result = runner.invoke(
-        app, ["task", "list", "--list-id", "list123", "--status", "in progress", "--assignee", "john.doe"]
+        app,
+        ["--format", "table", "task", "list", "--list-id", "list123", "--status", "in progress", "--assignee", "john.doe"],
     )
 
     assert result.exit_code == 0
@@ -369,7 +370,7 @@ def test_task_search(mock_get_client, sample_tasks):
 
     mock_get_client.side_effect = create_mock_client
 
-    result = runner.invoke(app, ["task", "search", "--query", "test", "--workspace-id", "workspace123"])
+    result = runner.invoke(app, ["--format", "table", "task", "search", "--query", "test", "--workspace-id", "workspace123"])
 
     assert result.exit_code == 0
     assert "Test Task" in result.stdout

--- a/tests/integration/test_workspace_commands.py
+++ b/tests/integration/test_workspace_commands.py
@@ -105,7 +105,7 @@ def test_workspace_list(mock_get_client, sample_teams):
     mock_client.get_teams.return_value = sample_teams
     mock_get_client.return_value.__aenter__.return_value = mock_client
 
-    result = runner.invoke(app, ["workspace", "list"])
+    result = runner.invoke(app, ["--format", "table", "workspace", "list"])
 
     assert result.exit_code == 0
     assert "Engineering Team" in result.output
@@ -120,7 +120,7 @@ def test_workspace_spaces(mock_get_client, sample_spaces):
     mock_client.get_spaces.return_value = sample_spaces
     mock_get_client.return_value.__aenter__.return_value = mock_client
 
-    result = runner.invoke(app, ["workspace", "spaces", "--workspace-id", "team123"])
+    result = runner.invoke(app, ["--format", "table", "workspace", "spaces", "--workspace-id", "team123"])
 
     assert result.exit_code == 0
     assert "Development" in result.output
@@ -135,7 +135,7 @@ def test_workspace_folders(mock_get_client, sample_folders):
     mock_client.get_folders.return_value = sample_folders
     mock_get_client.return_value.__aenter__.return_value = mock_client
 
-    result = runner.invoke(app, ["workspace", "folders", "--space-id", "space123"])
+    result = runner.invoke(app, ["--format", "table", "workspace", "folders", "--space-id", "space123"])
 
     assert result.exit_code == 0
     assert "Backend" in result.output
@@ -150,7 +150,7 @@ def test_workspace_members(mock_get_client, sample_members):
     mock_client.get_team_members.return_value = sample_members
     mock_get_client.return_value.__aenter__.return_value = mock_client
 
-    result = runner.invoke(app, ["workspace", "members", "--workspace-id", "team123"])
+    result = runner.invoke(app, ["--format", "table", "workspace", "members", "--workspace-id", "team123"])
 
     assert result.exit_code == 0
     assert "john.doe" in result.output
@@ -241,7 +241,7 @@ async def test_workspace_spaces_with_privacy_filter(mock_get_client, sample_spac
     mock_client.get_spaces.return_value = sample_spaces
     mock_get_client.return_value.__aenter__.return_value = mock_client
 
-    result = runner.invoke(app, ["workspace", "spaces", "--team-id", "team123", "--show-private"])
+    result = runner.invoke(app, ["--format", "table", "workspace", "spaces", "--team-id", "team123", "--show-private"])
 
     assert result.exit_code == 0
     assert "Development" in result.stdout
@@ -256,7 +256,7 @@ async def test_workspace_folders_with_task_counts(mock_get_client, sample_folder
     mock_client.get_folders.return_value = sample_folders
     mock_get_client.return_value.__aenter__.return_value = mock_client
 
-    result = runner.invoke(app, ["workspace", "folders", "--space-id", "space123", "--show-counts"])
+    result = runner.invoke(app, ["--format", "table", "workspace", "folders", "--space-id", "space123", "--show-counts"])
 
     assert result.exit_code == 0
     assert "Backend" in result.stdout
@@ -272,7 +272,7 @@ async def test_workspace_members_with_role_filter(mock_get_client, sample_member
     mock_client.get_team_members.return_value = sample_members
     mock_get_client.return_value.__aenter__.return_value = mock_client
 
-    result = runner.invoke(app, ["workspace", "members", "--team-id", "team123", "--role", "admin"])
+    result = runner.invoke(app, ["--format", "table", "workspace", "members", "--team-id", "team123", "--role", "admin"])
 
     assert result.exit_code == 0
     # Should filter to only show admins and owners

--- a/tests/integration/test_workspace_commands.py
+++ b/tests/integration/test_workspace_commands.py
@@ -256,7 +256,10 @@ async def test_workspace_folders_with_task_counts(mock_get_client, sample_folder
     mock_client.get_folders.return_value = sample_folders
     mock_get_client.return_value.__aenter__.return_value = mock_client
 
-    result = runner.invoke(app, ["--format", "table", "workspace", "folders", "--space-id", "space123", "--show-counts"])
+    result = runner.invoke(
+        app,
+        ["--format", "table", "workspace", "folders", "--space-id", "space123", "--show-counts"],
+    )
 
     assert result.exit_code == 0
     assert "Backend" in result.stdout
@@ -272,7 +275,10 @@ async def test_workspace_members_with_role_filter(mock_get_client, sample_member
     mock_client.get_team_members.return_value = sample_members
     mock_get_client.return_value.__aenter__.return_value = mock_client
 
-    result = runner.invoke(app, ["--format", "table", "workspace", "members", "--team-id", "team123", "--role", "admin"])
+    result = runner.invoke(
+        app,
+        ["--format", "table", "workspace", "members", "--team-id", "team123", "--role", "admin"],
+    )
 
     assert result.exit_code == 0
     # Should filter to only show admins and owners


### PR DESCRIPTION
## Summary
- Flip the cup CLI's default `--format` from `table` to `json`. Agents are first-class consumers, so the unflagged path should emit structured data; humans opt into tables with `--format table`.
- Update `AGENT.md` Decision #2 and the `--format` help text to reflect the new default.
- Patch the existing mock-driven integration tests that assert table-shaped output to pass `--format table` explicitly. Add a `test_list_show_defaults_to_json` to lock the new default in place.

## Test plan
- [x] `uv run pytest --cov=clickup` — 381 pass, 1 skip, 90.16% coverage (above the 90% gate from #19)
- [x] Manual: `cup status` (no flag) emits JSON; `cup --format table status` renders the table
- [x] Manual: `cup list show --folder-id <id>` emits the `{count, data}` JSON envelope by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)