### PR TITLE
bulk: fix .get() on pydantic models in dry-run preview

### DIFF
--- a/clickup/cli/commands/bulk.py
+++ b/clickup/cli/commands/bulk.py
@@ -316,8 +316,8 @@ def bulk_update(
                     updates["assignees"] = [new_assignee]
 
                 for task in tasks[:10]:  # Show first 10
-                    current_status = task.status.get("status", "Unknown") if task.status else "Unknown"
-                    current_priority = task.priority.get("priority", "None") if task.priority else "None"
+                    current_status = task.status.status if task.status else "Unknown"
+                    current_priority = (task.priority.priority or "None") if task.priority else "None"
 
                     table.add_row(
                         task.name[:30] + "..." if len(task.name) > 30 else task.name,

--- a/tests/integration/test_bulk_operations.py
+++ b/tests/integration/test_bulk_operations.py
@@ -39,10 +39,8 @@ def create_task_mocks(sample_tasks_json):
         task_mock.id = f"task_{task['name']}"
         task_mock.name = task["name"]
         task_mock.description = task["description"]
-        task_mock.status = Mock()
-        task_mock.status.get = Mock(return_value=task["status"])
-        task_mock.priority = Mock()
-        task_mock.priority.get = Mock(return_value=task["priority"])
+        task_mock.status = Mock(status=task["status"])
+        task_mock.priority = Mock(priority=task["priority"])
         task_mock.assignees = []
         task_mock.due_date = None
         task_mock.date_created = None
@@ -176,10 +174,8 @@ def test_bulk_update_without_flag_refuses(mock_get_client):
     task_mock = Mock()
     task_mock.id = "1"
     task_mock.name = "T"
-    task_mock.status = Mock()
-    task_mock.status.get = Mock(return_value="to do")
-    task_mock.priority = Mock()
-    task_mock.priority.get = Mock(return_value="medium")
+    task_mock.status = Mock(status="to do")
+    task_mock.priority = Mock(priority="medium")
     mock_client.get_tasks.return_value = [task_mock]
 
     def create_mock_client():
@@ -203,10 +199,8 @@ def test_bulk_update_tasks(mock_get_client):
         task_mock = Mock()
         task_mock.id = str(i)
         task_mock.name = f"Task {i}"
-        task_mock.status = Mock()
-        task_mock.status.get = Mock(return_value=status)
-        task_mock.priority = Mock()
-        task_mock.priority.get = Mock(return_value="medium")
+        task_mock.status = Mock(status=status)
+        task_mock.priority = Mock(priority="medium")
         mock_tasks.append(task_mock)
     mock_client.get_tasks.return_value = mock_tasks
     mock_client.update_task.return_value = Mock(id="1")
@@ -234,10 +228,8 @@ def test_bulk_update_with_filter(mock_get_client):
         task_mock = Mock()
         task_mock.id = str(i)
         task_mock.name = f"Task {i}"
-        task_mock.status = Mock()
-        task_mock.status.get = Mock(return_value=status)
-        task_mock.priority = Mock()
-        task_mock.priority.get = Mock(return_value=priority)
+        task_mock.status = Mock(status=status)
+        task_mock.priority = Mock(priority=priority)
         mock_tasks.append(task_mock)
     mock_client.get_tasks.return_value = mock_tasks
     mock_client.update_task.return_value = Mock(id="1")

--- a/tests/integration/test_final_coverage.py
+++ b/tests/integration/test_final_coverage.py
@@ -202,10 +202,8 @@ def test_bulk_update_dry_run(mock_get_client):
     task = Mock()
     task.id = "t1"
     task.name = "X"
-    task.status = Mock()
-    task.status.get = Mock(return_value="todo")
-    task.priority = Mock()
-    task.priority.get = Mock(return_value="medium")
+    task.status = Mock(status="todo")
+    task.priority = Mock(priority="medium")
     mock_client.get_tasks.return_value = [task]
     mock_get_client.return_value = _ctx(mock_client)
 


### PR DESCRIPTION
## Summary

`bulk-update` calls `task.status.get("status", ...)` and `task.priority.get("priority", ...)` when rendering the dry-run preview table. But `task.status` and `task.priority` are pydantic `StatusInfo` / `PriorityInfo` models — they have no `.get()` method. The code would raise `AttributeError` at runtime any time a real task with a status or priority hit the dry-run path.

The bug was masked by tests that mocked `.status.get` / `.priority.get` as `Mock(return_value=...)`, which sidestepped the actual model API.

## Fix

- `clickup/cli/commands/bulk.py` — switch to attribute access:
  - `task.status.status` (always `str` on `StatusInfo`)
  - `task.priority.priority or "None"` (`Optional[str]` on `PriorityInfo`)
- 5 test mock sites updated to `Mock(status=...)` / `Mock(priority=...)` so they match the real model surface.

## How it surfaced

`ty check` flagged it once my local ty drifted past the lockfile timestamp cutoff. CI is still green on the pinned `ty` version, but the bug is real — these expressions blow up at runtime, not just in the type checker. Worth fixing regardless.

## Test plan

- [x] `uv run pytest` → 389 passed, 1 skipped, 90.20% coverage
- [x] `uv run ty check` → clean
- [x] `uv run ruff check` / `format` → clean
- [x] `just fc` → end-to-end green locally (was previously blocked by these 2 errors)

## Diff size

3 files changed, 12 insertions(+), 22 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)