### PR TITLE
Finish P1 (issue #29): Typer error envelope, variadic verbs, priority sort docs

### DIFF
--- a/clickup/cli/commands/task.py
+++ b/clickup/cli/commands/task.py
@@ -303,7 +303,9 @@ def list_tasks(
         help=(
             "Sort tasks by: created, updated, due_date, priority. "
             "Direction syntax: 'updated:desc', '-updated' (desc), '+updated' or 'updated' (asc). "
-            "When direction is implicit, --reverse decides."
+            "When direction is implicit, --reverse decides. "
+            "Note: priority encodes 1=urgent..4=low numerically, so 'priority' (asc) "
+            "puts urgent first; 'priority:desc' puts low first. Tasks missing the field always sort last."
         ),
     ),
     reverse: bool = typer.Option(
@@ -434,7 +436,10 @@ def my_tasks(
         None,
         "--sort",
         "--order-by",
-        help="Sort by: created, updated, due_date, priority. Direction: 'priority:desc', '-priority', '+priority'.",
+        help=(
+            "Sort by: created, updated, due_date, priority. Direction: 'priority:desc', '-priority', '+priority'. "
+            "Priority is numeric (1=urgent..4=low), so 'priority' (asc) puts urgent first."
+        ),
     ),
     reverse: bool = typer.Option(False, "--reverse", help="Sort descending."),
     limit: int = typer.Option(50, "--limit", help="Maximum number of tasks to show"),
@@ -672,11 +677,6 @@ async def _do_status_change_many(task_ids: list[str], status: str) -> None:
         raise typer.Exit(1) from e
 
 
-async def _do_status_change(task_id: str, status: str) -> None:
-    """Shared single-task status update wrapper."""
-    await _do_status_change_many([task_id], status)
-
-
 def _usage_error(msg: str) -> NoReturn:
     """Emit a usage error per AGENT.md §4a (render_error → stderr, exit 2).
 
@@ -793,40 +793,40 @@ def change_status(
 
 @app.command("done")
 def task_done(
-    task_id: str = typer.Argument(..., help="Task ID"),
+    task_ids: list[str] = typer.Argument(..., metavar="TASK_ID...", help="One or more task IDs"),
     status: str = typer.Option(_DONE_STATUS, "--status", "-s", help=f"Target status name (default: '{_DONE_STATUS}')"),
 ) -> None:
-    """Close a task. Sets status to 'complete' unless --status overrides."""
-    run_async(_do_status_change(task_id, status))
+    """Close one or more tasks. Sets status to 'complete' unless --status overrides."""
+    run_async(_do_status_change_many(task_ids, status))
 
 
 @app.command("close")
 def task_close(
-    task_id: str = typer.Argument(..., help="Task ID"),
+    task_ids: list[str] = typer.Argument(..., metavar="TASK_ID...", help="One or more task IDs"),
     status: str = typer.Option(_DONE_STATUS, "--status", "-s", help=f"Target status name (default: '{_DONE_STATUS}')"),
 ) -> None:
-    """Close a task. Alias for `task done`."""
-    task_done(task_id=task_id, status=status)
+    """Close one or more tasks. Alias for `task done`."""
+    run_async(_do_status_change_many(task_ids, status))
 
 
 @app.command("start")
 def task_start(
-    task_id: str = typer.Argument(..., help="Task ID"),
+    task_ids: list[str] = typer.Argument(..., metavar="TASK_ID...", help="One or more task IDs"),
     status: str = typer.Option(
         _START_STATUS, "--status", "-s", help=f"Target status name (default: '{_START_STATUS}')"
     ),
 ) -> None:
-    """Move a task to 'in progress' unless --status overrides."""
-    run_async(_do_status_change(task_id, status))
+    """Move one or more tasks to 'in progress' unless --status overrides."""
+    run_async(_do_status_change_many(task_ids, status))
 
 
 @app.command("park")
 def task_park(
-    task_id: str = typer.Argument(..., help="Task ID"),
+    task_ids: list[str] = typer.Argument(..., metavar="TASK_ID...", help="One or more task IDs"),
     status: str = typer.Option(_PARK_STATUS, "--status", "-s", help=f"Target status name (default: '{_PARK_STATUS}')"),
 ) -> None:
-    """Park a task on the on-deck queue unless --status overrides."""
-    run_async(_do_status_change(task_id, status))
+    """Park one or more tasks on the on-deck queue unless --status overrides."""
+    run_async(_do_status_change_many(task_ids, status))
 
 
 @app.command("delete")

--- a/clickup/cli/main.py
+++ b/clickup/cli/main.py
@@ -2,7 +2,9 @@
 
 import asyncio
 import json
+import sys
 
+import click
 import typer
 from rich.console import Console
 from rich.table import Table
@@ -11,7 +13,7 @@ from ..core import Config, get_provider, provider_name, provider_requires_creden
 from .commands import api, bulk, config, discover, mock, task, templates, workspace
 from .commands import list as list_cmd
 from .commands import setup as setup_cmd
-from .output import FormatChoice, get_format, render_error, set_format
+from .output import FormatChoice, get_format, set_format
 
 app = typer.Typer(
     name="clickup",
@@ -245,16 +247,79 @@ async def async_main() -> None:
     app()
 
 
+def _wants_json_mode(argv: list[str]) -> bool:
+    """Inspect argv for ``--format`` before Click parses it.
+
+    The Typer root callback installs the format flag, but Click raises
+    UsageError *during* argument parsing — before the callback runs — so we
+    can't read ``get_format()`` here. JSON is the default per AGENT.md §2,
+    so anything except an explicit ``--format table`` (or ``--format csv``,
+    if ever supported) means JSON.
+    """
+    for i, arg in enumerate(argv):
+        if arg == "--format" and i + 1 < len(argv):
+            return argv[i + 1].lower() == "json"
+        if arg.startswith("--format="):
+            return arg.split("=", 1)[1].lower() == "json"
+    return True
+
+
+def _emit_click_error_envelope(exc: click.ClickException) -> None:
+    """Render a click.ClickException as the JSON ``{"error": ..., ...}`` envelope.
+
+    This closes the last gap from issue #29 P0 #2: Typer/Click usage errors
+    (unknown subcommand, ``--limit abc``, missing required arg) used to emit
+    Rich-formatted prose on stderr, bypassing the JSON envelope contract.
+    """
+    payload: dict[str, str] = {
+        "error": exc.format_message(),
+        "type": exc.__class__.__name__,
+    }
+    ctx = getattr(exc, "ctx", None)
+    if ctx is not None and ctx.command_path:
+        payload["command"] = ctx.command_path
+    typer.echo(json.dumps(payload), err=True)
+
+
 def main() -> None:
-    """Main entry point for the CLI."""
+    """Main entry point for the CLI.
+
+    Runs the Typer app with ``standalone_mode=False`` so we can route Click's
+    usage errors through the structured JSON envelope agents expect, instead
+    of letting Click format them as Rich prose on stderr.
+    """
+    json_mode = _wants_json_mode(sys.argv[1:])
     try:
-        app()
+        app(standalone_mode=False)
+    except click.exceptions.UsageError as e:
+        if json_mode:
+            _emit_click_error_envelope(e)
+        else:
+            e.show()
+        sys.exit(e.exit_code or 2)
+    except click.exceptions.ClickException as e:
+        # UsageError + its subclasses (NoSuchOption, BadParameter, etc.) are
+        # caught above; this clause catches the other ClickException branch,
+        # most realistically FileError.
+        if json_mode:
+            _emit_click_error_envelope(e)
+        else:
+            e.show()
+        sys.exit(e.exit_code or 1)
+    except click.exceptions.Abort:
+        # Ctrl+C path; mirror Click's default exit code without the noisy
+        # Rich traceback typer emits otherwise.
+        sys.exit(1)
+    except click.exceptions.Exit as e:
+        # typer.Exit raises this with an explicit code; honor it.
+        sys.exit(e.exit_code)
     except KeyboardInterrupt:
-        console.print("\n[yellow]Cancelled by user[/yellow]")
-        raise typer.Exit(1) from None
-    except Exception as e:
-        render_error(f"Error: {e}")
-        raise typer.Exit(1) from e
+        # Match the JSON contract on stderr in JSON mode; Rich prose for humans.
+        if json_mode:
+            typer.echo(json.dumps({"error": "Cancelled by user", "type": "KeyboardInterrupt"}), err=True)
+        else:
+            console.print("\n[yellow]Cancelled by user[/yellow]")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,13 @@ select = [
     "UP", # pyupgrade
 ]
 
+# Typer/Click param factories return immutable ParameterInfo singletons; ruff's
+# B008 (mutable-default) doesn't know this, so it flags `task_ids: list[str] =
+# typer.Argument(...)` even though the default is fine. Allowlist the framework
+# call sites so we don't have to noqa every signature.
+[tool.ruff.lint.flake8-bugbear]
+extend-immutable-calls = ["typer.Argument", "typer.Option"]
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"

--- a/tests/unit/test_main_error_envelope.py
+++ b/tests/unit/test_main_error_envelope.py
@@ -1,0 +1,98 @@
+"""Tests for the Typer/Click error JSON envelope wrapper in main()."""
+
+from __future__ import annotations
+
+import json
+
+import click
+import pytest
+
+from clickup.cli.main import _emit_click_error_envelope, _wants_json_mode, main
+
+
+@pytest.mark.parametrize(
+    "argv,expected",
+    [
+        ([], True),  # JSON is the default
+        (["task", "list"], True),
+        (["--format", "json", "task", "list"], True),
+        (["--format=json", "task", "list"], True),
+        (["--format", "JSON", "task", "list"], True),
+        (["--format", "table", "task", "list"], False),
+        (["--format=table", "task", "list"], False),
+        (["--format", "csv", "task", "list"], False),
+        (["task", "list", "--format", "json"], True),  # flag after subcommand still detected
+    ],
+)
+def test_wants_json_mode_parses_argv(argv: list[str], expected: bool) -> None:
+    assert _wants_json_mode(argv) is expected
+
+
+def test_emit_click_error_envelope_shape(capsys: pytest.CaptureFixture[str]) -> None:
+    """The envelope carries error, type, and (when available) command path."""
+    exc = click.exceptions.UsageError("No such command 'frobnicate'.")
+    # ctx is None for top-level errors; envelope should omit command then.
+    _emit_click_error_envelope(exc)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload == {"error": "No such command 'frobnicate'.", "type": "UsageError"}
+
+
+def test_emit_click_error_envelope_with_context(capsys: pytest.CaptureFixture[str]) -> None:
+    cmd = click.Command(name="list")
+    ctx = click.Context(cmd, info_name="list", parent=click.Context(click.Command(name="clickup"), info_name="clickup"))
+    exc = click.exceptions.BadParameter("not a valid integer", ctx=ctx, param_hint="'--limit'")
+    _emit_click_error_envelope(exc)
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert payload["error"].startswith("Invalid value for '--limit'")
+    assert payload["type"] == "BadParameter"
+    assert payload["command"] == "clickup list"
+
+
+def test_main_emits_json_envelope_for_unknown_subcommand(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: `clickup frobnicate` should exit 2 with a JSON error on stderr."""
+    monkeypatch.setattr("sys.argv", ["clickup", "frobnicate"])
+    with pytest.raises(SystemExit) as exit_info:
+        main()
+    assert exit_info.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["type"] == "UsageError"
+    assert "frobnicate" in payload["error"]
+
+
+def test_main_emits_json_envelope_for_bad_type_coercion(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`clickup task list --list-id L --limit abc` → JSON envelope, exit 2."""
+    monkeypatch.setattr("sys.argv", ["clickup", "task", "list", "--list-id", "L", "--limit", "abc"])
+    with pytest.raises(SystemExit) as exit_info:
+        main()
+    assert exit_info.value.code == 2
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert payload["type"] == "BadParameter"
+    assert "--limit" in payload["error"]
+
+
+def test_main_falls_back_to_rich_prose_for_table_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--format table` opts out of the JSON envelope; humans get the usual Click output."""
+    monkeypatch.setattr("sys.argv", ["clickup", "--format", "table", "frobnicate"])
+    with pytest.raises(SystemExit) as exit_info:
+        main()
+    assert exit_info.value.code == 2
+    captured = capsys.readouterr()
+    # Click's default format includes "No such command" prose on stderr.
+    assert "frobnicate" in captured.err
+    # Crucially, NOT a JSON envelope.
+    assert not captured.err.lstrip().startswith("{")


### PR DESCRIPTION
## Summary

Closes the last items the round-2 user study and 5-agent smoke test flagged for [issue #29](https://github.com/EvanOman/clickup-tools/issues/29).

- **Typer/Click parse-time errors → JSON envelope.** `clickup frobnicate`, `--limit abc`, missing required args — every Click `UsageError` / `BadParameter` / `NoSuchOption` / `MissingParameter` / `FileError` now emits `{"error": ..., "type": ..., "command": ...}` on stderr with exit 2 (or 1 for non-usage). Falls back to Click's Rich output when `--format table` is requested. Closes Agent 15's last 3 of 16 error paths.
- **`task done / close / start / park` are now variadic.** `cup task done T1 T2 T3` works in one invocation, routed through the pre-existing `_do_status_change_many` helper. Single-ID invocations unchanged. Direct answer to Agent 08's "had to run N commands instead of 1."
- **Priority sort direction documented inline.** `--sort` help on `task list` and `task mine` now spells out the numeric encoding (1=urgent..4=low), closing the smoke-C agent's complaint.
- **Bonus:** `KeyboardInterrupt` during a JSON-mode run emits the envelope (was Rich prose); `flake8-bugbear` allowlists `typer.Argument`/`typer.Option` so the new `list[str]` defaults don't trip B008.

## Reviewed by three sub-agents

- **Simplicity** — flagged the dead `_do_status_change` wrapper (deleted), KeyboardInterrupt+Rich in JSON mode (gated), envelope-shape divergence between `render_error` and the wrapper (acknowledged as covering distinct failure layers, tracked as P2).
- **Python correctness** — confirmed `standalone_mode=False` doesn't break `--help`, exception ordering is right, variadic `list[str] = typer.Argument(...)` with `...` is required-by-default. One comment fix (misleading subclass list) applied.
- **Agent-native ergonomics** — verdict: \"This finishes P1. Ship it.\" Suggested adding `type`/`command` fields to `render_error` for one canonical envelope shape; tracked as a follow-up.

## Smoke verification

```
$ clickup frobnicate
{\"error\": \"No such command 'frobnicate'.\", \"type\": \"UsageError\", \"command\": \"clickup\"}
exit 2

$ clickup task done mock_1002 mock_1004
{\"data\": [...], \"count\": 2}
  mock_1002 → complete
  mock_1004 → complete

$ clickup task list --help | grep \"priority encodes\"
priority encodes 1=urgent..4=low numerically, so 'priority' (asc) puts urgent first
```

## Test plan

- [x] 14 new tests in `tests/unit/test_main_error_envelope.py` cover `_wants_json_mode` parametrically, the envelope shape, and end-to-end via `monkeypatch.setattr('sys.argv', ...)` + `pytest.raises(SystemExit)`.
- [x] 491 total tests pass; lint, ty, format clean.
- [x] End-to-end smoke against the JSON provider verifies all three items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)