### PR TITLE
Standard backend OpenAPI contract + agent-facing docs overhaul

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -88,7 +88,7 @@ The CLI is backend-pluggable via the `TaskProvider` protocol
 
 - `clickup` (default) — the real SaaS; needs `CLICKUP_API_KEY`
 - `json` / `local` / `mock` — file-backed, **zero setup**; use this for development and evals
-- `planka` — self-hosted Kanban; live instance + local compose stack run from the private [planka-deploy](https://github.com/EvanOman/planka-deploy) repo (`/home/evan/dev/planka-deploy` locally)
+- `planka` — self-hosted Kanban; live instance + local compose stack run from the private [planka-deploy](https://github.com/EvanOman/planka-deploy) repo (`~/dev/planka-deploy` locally)
 
 Spin-up commands, env vars, and verification steps per backend: **`docs/backends.md`**.
 Deployment code never lives in this repo — adapters only.

--- a/AGENT.md
+++ b/AGENT.md
@@ -2,7 +2,17 @@
 
 ## Project goal in one line
 
-A Python CLI for ClickUp that an AI coding agent can drive end-to-end through stdin/stdout — no MCP, no UI, no skills required for basic use. Linear MCP's "modify if passed" semantics for writes.
+A task-management CLI that an AI coding agent can drive end-to-end through stdin/stdout — no MCP, no UI, no skills required for basic use. ClickUp is the default backend, but the CLI is backend-pluggable (see "Backends"). Linear MCP's "modify if passed" semantics for writes.
+
+## Docs map (start here if you're new)
+
+| You want to... | Read |
+|---|---|
+| Understand the system in 2 minutes | `docs/architecture.md` |
+| Run the CLI against a backend (incl. zero-infra local) | `docs/backends.md` |
+| Add a new backend adapter | `docs/writing-an-adapter.md` |
+| Implement a backend in another language | `spec/openapi.yaml` + `spec/README.md` |
+| Know the behavioral rules before changing code | this file, "Architecture decisions" |
 
 ## Technology stack (required)
 
@@ -51,19 +61,41 @@ clickup-toolkit/
 ├── pyproject.toml          # both `clickup` and `cup` entry points
 ├── justfile                # dev commands (`just fc` = format+lint+type+test)
 ├── clickup/
-│   ├── core/               # API client, config, models, exceptions
+│   ├── core/               # provider port, adapters, config, models, exceptions
+│   │   ├── providers.py    # TaskProvider protocol + get_provider() factory
+│   │   ├── client.py       # ClickUp adapter (default)
+│   │   ├── json_provider.py    # zero-infra local adapter
+│   │   └── planka_provider.py  # Planka adapter (reference for new adapters)
 │   ├── cli/
 │   │   ├── main.py         # Typer root, --format callback, status, version
 │   │   ├── output.py       # ALL output rendering (see "Output contract")
 │   │   ├── utils.py        # run_async + no-op spinner shim
 │   │   └── commands/       # per-feature subcommands
 │   └── nlp/                # PARKED — see "Parked features"
+├── docs/                   # architecture, backends, adapter guide
+├── spec/                   # OpenAPI contract for HTTP backends + design notes
 ├── tests/
 │   ├── unit/               # mocked
 │   ├── integration/        # mocked end-to-end CLI
 │   └── live/               # marked @pytest.mark.live, hits real API
 └── .claude/skills/cli-agent-eval/   # the regression eval (see below)
 ```
+
+## Backends (providers)
+
+The CLI is backend-pluggable via the `TaskProvider` protocol
+(`clickup/core/providers.py`). Select with `CLICKUP_PROVIDER`:
+
+- `clickup` (default) — the real SaaS; needs `CLICKUP_API_KEY`
+- `json` / `local` / `mock` — file-backed, **zero setup**; use this for development and evals
+- `planka` — self-hosted Kanban; live instance + local compose stack run from the private [planka-deploy](https://github.com/EvanOman/planka-deploy) repo (`/home/evan/dev/planka-deploy` locally)
+
+Spin-up commands, env vars, and verification steps per backend: **`docs/backends.md`**.
+Deployment code never lives in this repo — adapters only.
+
+Two contract surfaces, one source of truth: the Python protocol is canonical;
+`spec/openapi.yaml` is its HTTP projection for non-Python implementers. If a
+PR changes `TaskProvider` or the models, it must update the spec too.
 
 ## Architecture decisions (load-bearing — don't undo without reason)
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ See `AGENT.md` for development guidelines.
 
 ## Backends
 
-The CLI talks to any backend implementing the `TaskProvider` protocol (`clickup/core/providers.py`). Adapters live in this repo; backend *deployments* do not.
+The CLI talks to any backend implementing the `TaskProvider` protocol (`clickup/core/providers.py`). Adapters live in this repo; backend *deployments* do not. Per-backend setup and spin-up instructions: [docs/backends.md](docs/backends.md). Implementing a backend in another language? Target the [OpenAPI contract](spec/openapi.yaml) ([design notes](spec/README.md)).
 
 | Backend | Adapter | Deployment |
 |---------|---------|------------|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,82 @@
+# Architecture
+
+One diagram, then where to find everything.
+
+```
+                  ┌────────────────────────────────────────────┐
+                  │ clickup/cli/                               │
+  agent ──stdio──▶│   main.py        Typer root, global --format,
+                  │                  exit codes, JSON error envelope
+                  │   commands/*.py  per-feature subcommands    │
+                  │   output.py      ALL rendering (table/JSON) │
+                  └───────────────┬────────────────────────────┘
+                                  │ TaskProvider protocol
+                                  │ (clickup/core/providers.py)
+                  ┌───────────────┴────────────────────────────┐
+                  │ adapters (clickup/core/)                   │
+                  │   client.py           ClickUp SaaS (httpx) │
+                  │   json_provider.py    local JSON file      │
+                  │   planka_provider.py  Planka via plankapy  │
+                  └───────────────┬────────────────────────────┘
+                                  │ pydantic models (models.py)
+                                  ▼
+                          backend of choice
+```
+
+## The contract stack
+
+1. **`TaskProvider`** (`clickup/core/providers.py`) — the Python protocol all
+   adapters implement. ~25 async methods over the hierarchy
+   workspace → space → folder → list → task → comment. **Source of truth.**
+2. **`spec/openapi.yaml`** — the HTTP projection of that protocol, for
+   non-Python backend implementers. Derived; update it whenever the protocol
+   changes. Design rationale in `spec/README.md`.
+3. **Models** (`clickup/core/models.py`) — pydantic, ClickUp-shaped wire
+   format (epoch-ms-string timestamps, string IDs, `extra="allow"`
+   everywhere). Adapters translate their backend's shapes into these.
+
+## Key flows
+
+**Provider selection** — `get_provider()` reads `CLICKUP_PROVIDER` env var,
+then the `provider` config key, defaulting to `clickup`. See
+`docs/backends.md` for running each one.
+
+**Output** — every command renders through `clickup/cli/output.py`. JSON is
+the *default* format (agents are the primary consumer); `--format table` is
+the human opt-in. Collections emit `{"data": [...], "count": N}`.
+
+**Errors** — exceptions (`clickup/core/exceptions.py`) are caught in
+`main.py` and rendered by `render_error()` to **stderr** (as `{"error": ...}`
+in JSON mode), keeping stdout clean for pipelines. Exit codes: `0` success,
+`1` runtime/API error, `2` usage error (including refused destructive ops).
+
+**Config** — `~/.config/clickup-toolkit/config.json` plus `.env` loading;
+env vars always win. `default_lists` maps aliases (e.g. `omegapoint`) to list
+IDs so agents don't need discovery calls.
+
+## Behavioral contracts (don't break these)
+
+Full rationale in `AGENT.md` → "Architecture decisions". The headlines:
+
+- JSON to stdout, errors to stderr, no spinners — agents pipe stdout.
+- `--format` is global (root callback), never per-command.
+- Updates are modify-if-passed: only explicitly passed fields change;
+  `--description ""` clears.
+- Destructive ops never prompt; they require `--force`/`--yes` or exit 2.
+- Rich markup is escaped on all user data (`[bug] foo` must survive).
+
+## Testing
+
+- `tests/unit/` — mocked, fast.
+- `tests/integration/` — mocked end-to-end CLI invocations.
+- `tests/live/` — `@pytest.mark.live`, hits real ClickUp (`just test-live`).
+- `.claude/skills/cli-agent-eval` — 12-task agent swarm regression eval; run
+  after non-trivial CLI changes.
+- `just fc` before every commit (format + lint + type + test).
+
+## Related repos
+
+- **[EvanOman/planka-deploy](https://github.com/EvanOman/planka-deploy)**
+  (private) — runs the Planka backend: Railway infra, Caddy proxy, backups,
+  local compose stack, seed data. This repo deliberately contains no
+  deployment code.

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -61,14 +61,14 @@ Env vars (read by `planka_provider.py`):
 | Var | Default | Notes |
 |---|---|---|
 | `PLANKA_URL` | `http://localhost:18920` | Base URL of the Planka instance |
-| `PLANKA_EMAIL` (or `PLANKA_USERNAME`) | `admin` | Login identity |
-| `PLANKA_PASSWORD` | — (required) | Login password |
+| `PLANKA_USERNAME` (falls back to `PLANKA_EMAIL`) | `admin` | Login identity — `PLANKA_USERNAME` wins if both are set |
+| `PLANKA_PASSWORD` | `""` (empty) | Effectively required: an unset password attempts login with `""` and fails with an auth error, not a "missing env var" message |
 
 ### Option A: the live deployment (Railway)
 
 Deployment and ops live in the **private repo
 [EvanOman/planka-deploy](https://github.com/EvanOman/planka-deploy)**
-(locally at `/home/evan/dev/planka-deploy` on Evan's machine).
+(locally at `~/dev/planka-deploy` on Evan's machine).
 
 ```bash
 export CLICKUP_PROVIDER=planka
@@ -81,17 +81,18 @@ uv run clickup discover hierarchy
 ### Option B: spin up Planka locally
 
 ```bash
-docker compose -f /home/evan/dev/planka-deploy/local/docker-compose.yml up -d
+COMPOSE=~/dev/planka-deploy/local/docker-compose.yml
+docker compose -f "$COMPOSE" up -d
 # wait ~15s for first boot, then:
 export CLICKUP_PROVIDER=planka
 export PLANKA_EMAIL=admin@local
-export PLANKA_PASSWORD='Planka!Admin2025#Secure'   # local-only default, see compose file
+export PLANKA_PASSWORD=$(grep -oP 'DEFAULT_ADMIN_PASSWORD=\K.*' "$COMPOSE")
 uv run clickup status
 ```
 
 The local instance serves on `http://localhost:18920` (the adapter's default
 URL, so `PLANKA_URL` can be omitted). To populate it with the canonical
-25-task TaskFlow dataset: `uv run /home/evan/dev/planka-deploy/seed/seed.py`.
+25-task TaskFlow dataset: `uv run ~/dev/planka-deploy/seed/seed.py`.
 
 Tear down with `docker compose -f .../local/docker-compose.yml down`
 (add `-v` to also wipe data).

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,110 @@
+# Backends: how to run the CLI against each provider
+
+The CLI talks to backends through the `TaskProvider` port
+(`clickup/core/providers.py`). Select a backend with the `CLICKUP_PROVIDER`
+env var (or the `provider` config key):
+
+| `CLICKUP_PROVIDER` | Adapter | Needs infra? | Use for |
+|---|---|---|---|
+| `clickup` (default) | `clickup/core/client.py` | No (SaaS) | Real ClickUp workspaces |
+| `json` (aliases: `local`, `mock`) | `clickup/core/json_provider.py` | **No — zero setup** | Development, evals, offline testing |
+| `planka` | `clickup/core/planka_provider.py` | Yes (self-hosted Kanban) | Open-source backend |
+| `generic` | planned — see `spec/README.md` | Yes (any spec-conformant server) | Non-Python backends |
+
+Verify any backend with:
+
+```bash
+uv run clickup status              # auth + config check
+uv run clickup discover hierarchy  # walk workspace -> space -> list
+```
+
+---
+
+## json — zero-infra local backend (start here)
+
+No credentials, no network, no containers. Ideal when developing the CLI
+itself or testing agent workflows.
+
+```bash
+export CLICKUP_PROVIDER=json
+uv run clickup discover hierarchy
+uv run clickup task list --list-id <id from discover>
+```
+
+- State lives in a single JSON file: `~/.config/clickup-toolkit/mock-store.json`
+  (created with a deterministic seed workspace on first use).
+- Point at a different store with `CLICKUP_JSON_STORE=/path/to/store.json` —
+  use a throwaway path in tests/evals so you don't clobber other runs.
+- The seed workspace has statuses `to do / in progress / on-deck / complete`.
+
+## clickup — the real SaaS (default)
+
+```bash
+export CLICKUP_API_KEY=pk_...        # or CLICKUP_API_TOKEN
+uv run clickup status
+```
+
+- Token priority: env var > persisted config (`~/.config/clickup-toolkit/config.json`).
+- First-time interactive setup: `uv run clickup setup run`
+  (agents: pass `--token/--team-id/--space-id/--list-id/--non-interactive`).
+- `.env` files are auto-loaded from `~/.config/clickup-toolkit/.env` and the
+  current working directory.
+
+## planka — self-hosted Kanban
+
+The adapter maps Planka's model onto the task hierarchy:
+project→space, board→list, column→status, card→task. Folders are synthetic
+(`folder_<spaceId>`); `raw_request` is unsupported.
+
+Env vars (read by `planka_provider.py`):
+
+| Var | Default | Notes |
+|---|---|---|
+| `PLANKA_URL` | `http://localhost:18920` | Base URL of the Planka instance |
+| `PLANKA_EMAIL` (or `PLANKA_USERNAME`) | `admin` | Login identity |
+| `PLANKA_PASSWORD` | — (required) | Login password |
+
+### Option A: the live deployment (Railway)
+
+Deployment and ops live in the **private repo
+[EvanOman/planka-deploy](https://github.com/EvanOman/planka-deploy)**
+(locally at `/home/evan/dev/planka-deploy` on Evan's machine).
+
+```bash
+export CLICKUP_PROVIDER=planka
+export PLANKA_URL=https://caddy-production-5cac.up.railway.app
+export PLANKA_EMAIL=admin@taskflow.cloud
+export PLANKA_PASSWORD=...   # PLANKA_ADMIN_PASSWORD in planka-deploy/.secrets/railway-deploy.env
+uv run clickup discover hierarchy
+```
+
+### Option B: spin up Planka locally
+
+```bash
+docker compose -f /home/evan/dev/planka-deploy/local/docker-compose.yml up -d
+# wait ~15s for first boot, then:
+export CLICKUP_PROVIDER=planka
+export PLANKA_EMAIL=admin@local
+export PLANKA_PASSWORD='Planka!Admin2025#Secure'   # local-only default, see compose file
+uv run clickup status
+```
+
+The local instance serves on `http://localhost:18920` (the adapter's default
+URL, so `PLANKA_URL` can be omitted). To populate it with the canonical
+25-task TaskFlow dataset: `uv run /home/evan/dev/planka-deploy/seed/seed.py`.
+
+Tear down with `docker compose -f .../local/docker-compose.yml down`
+(add `-v` to also wipe data).
+
+### No access to planka-deploy?
+
+Use the `json` provider — it exercises the same CLI surface with zero infra.
+The planka adapter itself only needs *any* reachable Planka instance
+(`ghcr.io/plankanban/planka` on Docker Hub) plus the three env vars above.
+
+## generic — bring your own backend (planned)
+
+`spec/openapi.yaml` defines the REST contract. Implement it (any language)
+and the planned `GenericProvider` will drive it via `TASKBACKEND_URL` +
+`TASKBACKEND_TOKEN`. Until that adapter lands, the spec is the design target
+for new shims; see `spec/README.md` for conformance levels.

--- a/docs/writing-an-adapter.md
+++ b/docs/writing-an-adapter.md
@@ -1,0 +1,100 @@
+# Writing a new backend adapter
+
+How to add a backend as a native Python adapter. (If you'd rather not write
+Python in this repo, implement `spec/openapi.yaml` as an HTTP shim instead —
+see `spec/README.md`.)
+
+`clickup/core/planka_provider.py` is the reference implementation: a complete
+adapter for a backend whose concepts *don't* match the task hierarchy, showing
+every degradation pattern below.
+
+## Steps
+
+### 1. Write the concept mapping first
+
+Top-of-file docstring, before any code. Decide what maps to what and what
+doesn't exist:
+
+```python
+"""Foo task provider — maps Foo's model to the TaskProvider protocol.
+
+Concept mapping (TaskProvider -> Foo):
+    Team/Workspace  -> synthetic singleton
+    Space           -> Foo Project
+    Folder          -> no-op (returns [] / synthetic placeholder)
+    List            -> Foo Board
+    Status          -> Foo Column
+    Task            -> Foo Card
+    Comment         -> Foo Comment
+"""
+```
+
+If you can't fill this table in, stop — the adapter will be a pile of special
+cases.
+
+### 2. Implement `TaskProvider`
+
+Create `clickup/core/foo_provider.py` with a class implementing every method
+of the protocol (`clickup/core/providers.py`). It's a `typing.Protocol` —
+no inheritance, just matching signatures. Rules:
+
+- Return the pydantic models from `clickup/core/models.py`, never raw dicts.
+- IDs on the wire are **strings** (stringify your backend's ints; see
+  `_sid()` in the Planka adapter). User IDs stay integers.
+- Timestamps are **epoch-ms strings** (`_iso_to_ms()` shows the conversion).
+- Read connection config from env vars prefixed with your backend name
+  (`FOO_URL`, `FOO_TOKEN`, ...), with sane localhost defaults.
+- Raise the typed exceptions from `clickup/core/exceptions.py`
+  (`NotFoundError`, `ValidationError`, `AuthenticationError`, ...) — `main.py`
+  maps them onto exit codes and the stderr error envelope.
+
+### 3. Degrade honestly, don't fake
+
+For concepts your backend lacks:
+
+| Missing concept | Pattern (from PlankaProvider) |
+|---|---|
+| Multi-workspace | Synthesize one workspace from the logged-in user |
+| Folders | Return one synthetic placeholder per space, id `folder_<spaceId>`; reject `create_folder` with `ValidationError` |
+| Raw API passthrough | Raise `ValidationError("raw_request not supported for Foo: ...")` |
+| Anything else | Raise `ValidationError` with a message that tells the agent what to do instead |
+
+Never silently return wrong data; agents act on it.
+
+### 4. Register the adapter
+
+In `clickup/core/providers.py`:
+
+- Add a branch to `get_provider()` (import inside the branch so the
+  dependency stays lazy).
+- Add the name to `provider_requires_credentials()` if it needs auth.
+- Extend the `ValueError` message listing valid provider names.
+
+If the backend needs an SDK, add it to `pyproject.toml` dependencies.
+
+### 5. Test it
+
+- Unit tests with a faked SDK/HTTP layer under `tests/unit/`.
+- Smoke-test the real thing end-to-end:
+
+  ```bash
+  CLICKUP_PROVIDER=foo FOO_URL=... uv run clickup discover hierarchy
+  CLICKUP_PROVIDER=foo ... uv run clickup task create "test" --list-id <id>
+  ```
+
+- `just fc` must pass. If the adapter is an early prototype, you may exclude
+  it from coverage/ty in `pyproject.toml` (the Planka adapter is excluded) —
+  but say so in the PR.
+- For agent-facing changes, run the `cli-agent-eval` skill.
+
+### 6. Update the contract surface
+
+- New provider name + env vars → document in `docs/backends.md`.
+- If you had to *change* `TaskProvider` or the models, update
+  `spec/openapi.yaml` in the same PR (the spec is derived from the protocol).
+
+## History note
+
+Three adapters were prototyped as a bake-off (Planka, Plane, Todoist — PRs
+#30/#31/#32). Planka won and is merged; the other two live on the
+`adapter/plane` and `adapter/todoist` branches as additional worked examples.

--- a/spec/README.md
+++ b/spec/README.md
@@ -31,7 +31,7 @@ speaks exactly this spec.
 
 | `TaskProvider` method | HTTP |
 |---|---|
-| `get_user` / `validate_auth` | `GET /me` (200 = valid, 401 = invalid) |
+| `get_user` / `validate_auth` | `GET /me` (200 = valid, 401 = invalid)¹ |
 | `get_teams` | `GET /workspaces` |
 | `get_team` | `GET /workspaces/{id}` |
 | `get_team_members` | `GET /workspaces/{id}/members` |
@@ -55,6 +55,11 @@ speaks exactly this spec.
 | `search_tasks` | `GET /workspaces/{id}/search/tasks` |
 | `raw_request` | **not in the spec** — backend-native escape hatch, not portable |
 | — | `GET /capabilities` (no protocol equivalent; formalizes adapter degradation) |
+
+¹ `validate_auth` returns `(bool, str, User | None)` in the protocol; over
+HTTP the boolean is carried entirely by the status code (200 → `(True, ...,
+User)`, 401 → `(False, ..., None)`) and the body is just a `User`. A bare 401
+with no body is valid — clients must not require an error envelope here.
 
 ## Design decisions
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,117 @@
+# Standard Task Backend contract
+
+`openapi.yaml` defines the HTTP contract a server must implement to act as a
+backend for this CLI. It is the HTTP projection of the Python `TaskProvider`
+protocol in `clickup/core/providers.py`.
+
+**Source of truth: the Python protocol.** The spec is derived from it. If you
+change `TaskProvider` (or the pydantic models it returns), update the spec in
+the same PR.
+
+## Why this exists
+
+The CLI talks to backends through `TaskProvider`, an in-process Python
+protocol. That is the cheapest extension point if you're writing Python in
+this repo — but invisible to everyone else. The OpenAPI spec gives non-Python
+adopters a target: implement this small REST surface (any language, typically
+as a thin shim in front of your existing tool) and the CLI can drive it via
+the generic provider with zero code changes here.
+
+## Two ways to add a backend
+
+| Route | Write | Best when |
+|---|---|---|
+| **Native adapter** | A Python class implementing `TaskProvider`, registered in `get_provider()` | You're contributing to this repo; the backend has a Python SDK (see `planka_provider.py`) |
+| **Spec-conformant shim** | An HTTP service implementing `spec/openapi.yaml` | You don't want to touch this repo; your backend logic isn't Python; you want one shim to serve many CLI installs |
+
+The generic provider (`CLICKUP_PROVIDER=generic`, planned — see Status below)
+speaks exactly this spec.
+
+## Protocol ↔ endpoint mapping
+
+| `TaskProvider` method | HTTP |
+|---|---|
+| `get_user` / `validate_auth` | `GET /me` (200 = valid, 401 = invalid) |
+| `get_teams` | `GET /workspaces` |
+| `get_team` | `GET /workspaces/{id}` |
+| `get_team_members` | `GET /workspaces/{id}/members` |
+| `get_spaces` | `GET /workspaces/{id}/spaces` |
+| `get_space` | `GET /spaces/{id}` |
+| `get_folders` | `GET /spaces/{id}/folders` |
+| `create_folder` | `POST /spaces/{id}/folders` |
+| `get_folder` | `GET /folders/{id}` |
+| `get_lists` | `GET /folders/{id}/lists` |
+| `create_list` | `POST /folders/{id}/lists` |
+| `get_folderless_lists` | `GET /spaces/{id}/lists` |
+| `create_folderless_list` | `POST /spaces/{id}/lists` |
+| `get_list` | `GET /lists/{id}` |
+| `get_tasks` | `GET /lists/{id}/tasks` (+ filter query params) |
+| `create_task` | `POST /lists/{id}/tasks` |
+| `get_task` | `GET /tasks/{id}` |
+| `update_task` | `PATCH /tasks/{id}` |
+| `delete_task` | `DELETE /tasks/{id}` |
+| `get_task_comments` | `GET /tasks/{id}/comments` |
+| `create_comment` | `POST /tasks/{id}/comments` |
+| `search_tasks` | `GET /workspaces/{id}/search/tasks` |
+| `raw_request` | **not in the spec** — backend-native escape hatch, not portable |
+| — | `GET /capabilities` (no protocol equivalent; formalizes adapter degradation) |
+
+## Design decisions
+
+**Vocabulary follows the CLI, not the backend.** Workspace → space →
+folder → list → task → comment. The CLI's JSON output, models, and flags all
+use these terms; a shim translates once (its tool's terms → spec terms)
+instead of every consumer translating differently. The Planka adapter's
+mapping (project→space, board→list, column→status, card→task) is the worked
+example.
+
+**Folders are optional, not core.** Planka proved a backend can live without
+them: declare `folders: false` in `/capabilities`, or synthesize one
+placeholder folder per space (`folder_<spaceId>`). Same choice for `search`
+and `delete_tasks`.
+
+**Capability discovery beats faking it.** `GET /capabilities` returns flags;
+omitted keys default to true; a 404 on the endpoint means "everything
+supported". Unsupported calls return `400` with error code `unsupported`.
+
+**Wire formats are ClickUp-shaped on purpose.** Epoch-ms-string timestamps,
+string IDs (integer user IDs), priority written as int 1–4 / read as an
+object, `task_count` as a string on folders. These are warts, but the CLI's
+pydantic models already speak them, and inventing a cleaner wire format would
+force a translation layer inside the CLI for zero user-visible benefit.
+
+**Modify-if-passed is contractual.** `PATCH /tasks/{id}` only touches fields
+present in the body, and an explicit `""` clears a field. This mirrors the
+CLI's update semantics (AGENT.md, architecture decision 3) — a server that
+treats absent and empty as the same will corrupt agent workflows.
+
+**All schemas are open.** Servers may add fields; clients must ignore unknown
+fields (models use `extra="allow"`). `comment_count` on tasks and `statuses`
+on lists are RECOMMENDED extras the CLI already understands.
+
+**Errors are a typed envelope.** `{"error": {"code", "message"}}` with codes
+mapping 1:1 onto `clickup/core/exceptions.py`
+(`authentication`/`authorization`/`not_found`/`validation`/`rate_limit`/
+`unsupported`/`server`). 429 responses should include `Retry-After`.
+
+**No pagination (yet).** No CLI call site passes paging filters; collections
+return everything. If a backend can't, that's the first thing to version the
+spec for.
+
+**Filter honesty.** Servers MUST honor `statuses` and `include_closed` on
+`GET /lists/{id}/tasks`; the date filters SHOULD be honored but the CLI
+treats server-side filtering as best-effort.
+
+## Conformance levels
+
+- **Minimal**: `/me`, `/workspaces*`, `/spaces/{id}/lists`, `/lists/{id}`,
+  `/lists/{id}/tasks` (GET+POST), `/tasks/{id}` (GET+PATCH), comments, and
+  `/capabilities` declaring everything else false. This is enough for the
+  CLI's core agent workflow (discover → list → create → update → comment).
+- **Full**: everything in the spec.
+
+## Status
+
+- [x] Spec drafted (v0.1.0)
+- [ ] `GenericProvider` adapter (`CLICKUP_PROVIDER=generic`, reads `TASKBACKEND_URL` + `TASKBACKEND_TOKEN`)
+- [ ] Conformance test suite runnable against any base URL

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,0 +1,941 @@
+openapi: 3.1.0
+info:
+  title: Standard Task Backend API
+  version: 0.1.0
+  description: |
+    The HTTP projection of the `TaskProvider` protocol
+    (`clickup/core/providers.py`) consumed by the clickup-tools CLI.
+
+    Any server implementing this spec can act as a backend for the CLI via the
+    generic provider (`CLICKUP_PROVIDER=generic`), with no Python code required.
+
+    **Source of truth:** the Python `TaskProvider` protocol. This spec is
+    derived from it; if the two disagree, the protocol wins and this file has a
+    bug.
+
+    ## Resource hierarchy
+
+        workspace -> space -> [folder] -> list -> task -> comment
+
+    Folders are an OPTIONAL capability (see `GET /capabilities`). Backends
+    without a folder concept (e.g. Kanban tools like Planka) either omit them
+    or synthesize one placeholder folder per space.
+
+    ## Conventions
+
+    - **IDs** are opaque strings, except user IDs which are integers.
+    - **Timestamps** are epoch-milliseconds encoded as strings
+      (e.g. `"1781059930000"`), matching ClickUp's wire format. ISO 8601 is
+      NOT accepted.
+    - **Priority** is written as an integer 1-4 (1=urgent, 2=high, 3=normal,
+      4=low) and read back as a `PriorityInfo` object.
+    - **Collections** are returned as `{"data": [...], "count": N}`.
+    - **All object schemas are open**: servers MAY include extra fields and
+      clients MUST ignore unknown fields (the CLI's pydantic models use
+      `extra="allow"`).
+    - **`GET /me` doubles as auth validation**: 200 means the credential is
+      valid; 401 means it is not.
+
+    ## Capability discovery
+
+    `GET /capabilities` lets minimal backends declare unsupported surface
+    instead of faking it. A 404 from this endpoint means "assume everything is
+    supported". Calling an endpoint whose capability is declared `false`
+    returns `400` with error code `unsupported`.
+servers:
+  - url: /api/v1
+security:
+  - bearerAuth: []
+
+tags:
+  - name: auth
+    description: Identity and credential validation
+  - name: hierarchy
+    description: Workspaces, spaces, folders, lists
+  - name: tasks
+    description: Task CRUD and search
+  - name: comments
+    description: Task comments
+
+paths:
+  /me:
+    get:
+      operationId: getUser
+      summary: Current user (also serves as auth validation)
+      description: Maps to `TaskProvider.get_user` and `validate_auth`.
+      tags: [auth]
+      responses:
+        "200":
+          description: The authenticated user.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/User" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /capabilities:
+    get:
+      operationId: getCapabilities
+      summary: Declare which optional capabilities this backend supports
+      tags: [auth]
+      security: []
+      responses:
+        "200":
+          description: Capability flags.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Capabilities" }
+
+  /workspaces:
+    get:
+      operationId: listWorkspaces
+      summary: List workspaces visible to the caller
+      description: |
+        Maps to `TaskProvider.get_teams`. Single-tenant backends return a
+        synthetic singleton (see the Planka adapter for the reference
+        behavior).
+      tags: [hierarchy]
+      responses:
+        "200":
+          description: Workspaces.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspaceCollection"
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /workspaces/{workspaceId}:
+    get:
+      operationId: getWorkspace
+      summary: Get one workspace
+      description: Maps to `TaskProvider.get_team`.
+      tags: [hierarchy]
+      parameters: [{ $ref: "#/components/parameters/workspaceId" }]
+      responses:
+        "200":
+          description: The workspace.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Workspace" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /workspaces/{workspaceId}/members:
+    get:
+      operationId: listWorkspaceMembers
+      summary: List members of a workspace
+      description: Maps to `TaskProvider.get_team_members`.
+      tags: [hierarchy]
+      parameters: [{ $ref: "#/components/parameters/workspaceId" }]
+      responses:
+        "200":
+          description: Members.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data]
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: "#/components/schemas/User" }
+                  count: { type: integer }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /workspaces/{workspaceId}/spaces:
+    get:
+      operationId: listSpaces
+      summary: List spaces in a workspace
+      description: Maps to `TaskProvider.get_spaces`.
+      tags: [hierarchy]
+      parameters: [{ $ref: "#/components/parameters/workspaceId" }]
+      responses:
+        "200":
+          description: Spaces.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data]
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: "#/components/schemas/Space" }
+                  count: { type: integer }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /workspaces/{workspaceId}/search/tasks:
+    get:
+      operationId: searchTasks
+      summary: Search tasks across a workspace (optional capability `search`)
+      description: |
+        Maps to `TaskProvider.search_tasks`. Case-insensitive substring match
+        against task names at minimum; backends MAY also match descriptions.
+      tags: [tasks]
+      parameters:
+        - { $ref: "#/components/parameters/workspaceId" }
+        - name: query
+          in: query
+          required: true
+          schema: { type: string }
+        - name: assignees
+          in: query
+          description: Restrict to tasks assigned to any of these user IDs.
+          schema:
+            type: array
+            items: { type: string }
+          style: form
+          explode: true
+      responses:
+        "200":
+          description: Matching tasks.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskCollection" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /spaces/{spaceId}:
+    get:
+      operationId: getSpace
+      summary: Get one space
+      description: Maps to `TaskProvider.get_space`.
+      tags: [hierarchy]
+      parameters: [{ $ref: "#/components/parameters/spaceId" }]
+      responses:
+        "200":
+          description: The space.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Space" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /spaces/{spaceId}/folders:
+    get:
+      operationId: listFolders
+      summary: List folders in a space (optional capability `folders`)
+      description: |
+        Maps to `TaskProvider.get_folders`. Backends without folders either
+        declare `folders: false` in capabilities, or return one synthetic
+        placeholder folder per space (id `folder_<spaceId>`) so that
+        folder-based navigation still works.
+      tags: [hierarchy]
+      parameters: [{ $ref: "#/components/parameters/spaceId" }]
+      responses:
+        "200":
+          description: Folders.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data]
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: "#/components/schemas/Folder" }
+                  count: { type: integer }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
+    post:
+      operationId: createFolder
+      summary: Create a folder (optional capability `folders`)
+      description: Maps to `TaskProvider.create_folder`.
+      tags: [hierarchy]
+      parameters: [{ $ref: "#/components/parameters/spaceId" }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+      responses:
+        "201":
+          description: The created folder.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Folder" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /folders/{folderId}:
+    get:
+      operationId: getFolder
+      summary: Get one folder (optional capability `folders`)
+      description: Maps to `TaskProvider.get_folder`.
+      tags: [hierarchy]
+      parameters: [{ $ref: "#/components/parameters/folderId" }]
+      responses:
+        "200":
+          description: The folder.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Folder" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /folders/{folderId}/lists:
+    get:
+      operationId: listLists
+      summary: List lists in a folder
+      description: Maps to `TaskProvider.get_lists`.
+      tags: [hierarchy]
+      parameters: [{ $ref: "#/components/parameters/folderId" }]
+      responses:
+        "200":
+          description: Lists.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ListCollection" }
+        "404": { $ref: "#/components/responses/NotFound" }
+    post:
+      operationId: createList
+      summary: Create a list in a folder
+      description: Maps to `TaskProvider.create_list`.
+      tags: [hierarchy]
+      parameters: [{ $ref: "#/components/parameters/folderId" }]
+      requestBody:
+        $ref: "#/components/requestBodies/CreateList"
+      responses:
+        "201":
+          description: The created list.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/List" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /spaces/{spaceId}/lists:
+    get:
+      operationId: listFolderlessLists
+      summary: List lists directly under a space (not inside any folder)
+      description: |
+        Maps to `TaskProvider.get_folderless_lists`. For backends without
+        folders this is THE list enumeration: every list in the space.
+      tags: [hierarchy]
+      parameters: [{ $ref: "#/components/parameters/spaceId" }]
+      responses:
+        "200":
+          description: Lists.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ListCollection" }
+        "404": { $ref: "#/components/responses/NotFound" }
+    post:
+      operationId: createFolderlessList
+      summary: Create a list directly under a space
+      description: Maps to `TaskProvider.create_folderless_list`.
+      tags: [hierarchy]
+      parameters: [{ $ref: "#/components/parameters/spaceId" }]
+      requestBody:
+        $ref: "#/components/requestBodies/CreateList"
+      responses:
+        "201":
+          description: The created list.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/List" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /lists/{listId}:
+    get:
+      operationId: getList
+      summary: Get one list
+      description: |
+        Maps to `TaskProvider.get_list`. Servers SHOULD include the list's
+        available statuses (workflow columns) via an extra `statuses` field so
+        clients can discover valid values for task status writes.
+      tags: [hierarchy]
+      parameters: [{ $ref: "#/components/parameters/listId" }]
+      responses:
+        "200":
+          description: The list.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/List" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /lists/{listId}/tasks:
+    get:
+      operationId: listTasks
+      summary: List tasks in a list
+      description: |
+        Maps to `TaskProvider.get_tasks`. Servers MUST honor `statuses` and
+        `include_closed`; the remaining filters SHOULD be honored and MAY be
+        ignored (the CLI treats server filtering as best-effort and refines
+        client-side).
+      tags: [tasks]
+      parameters:
+        - { $ref: "#/components/parameters/listId" }
+        - name: statuses
+          in: query
+          description: Only tasks whose status name is in this set.
+          schema:
+            type: array
+            items: { type: string }
+          style: form
+          explode: true
+        - name: assignees
+          in: query
+          description: Only tasks assigned to any of these user IDs.
+          schema:
+            type: array
+            items: { type: string }
+          style: form
+          explode: true
+        - name: include_closed
+          in: query
+          description: Include tasks in closed/done statuses. Default false.
+          schema: { type: boolean, default: false }
+        - name: date_created_gt
+          in: query
+          description: Epoch-ms lower bound on creation time.
+          schema: { type: integer, format: int64 }
+        - name: date_created_lt
+          in: query
+          schema: { type: integer, format: int64 }
+        - name: date_updated_gt
+          in: query
+          schema: { type: integer, format: int64 }
+        - name: date_updated_lt
+          in: query
+          schema: { type: integer, format: int64 }
+      responses:
+        "200":
+          description: Tasks.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskCollection" }
+        "404": { $ref: "#/components/responses/NotFound" }
+    post:
+      operationId: createTask
+      summary: Create a task
+      description: |
+        Maps to `TaskProvider.create_task`. If `status` is omitted the task
+        goes to the list's first/default status column.
+      tags: [tasks]
+      parameters: [{ $ref: "#/components/parameters/listId" }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+                description: { type: string }
+                status:
+                  type: string
+                  description: Status name; must exist on the target list.
+                priority:
+                  $ref: "#/components/schemas/PriorityWrite"
+                due_date:
+                  $ref: "#/components/schemas/EpochMillis"
+                assignees:
+                  type: array
+                  items: { type: string }
+                  description: User IDs to assign.
+      responses:
+        "201":
+          description: The created task.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Task" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /tasks/{taskId}:
+    get:
+      operationId: getTask
+      summary: Get one task
+      description: Maps to `TaskProvider.get_task`.
+      tags: [tasks]
+      parameters: [{ $ref: "#/components/parameters/taskId" }]
+      responses:
+        "200":
+          description: The task.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Task" }
+        "404": { $ref: "#/components/responses/NotFound" }
+    patch:
+      operationId: updateTask
+      summary: Update a task (modify-if-passed semantics)
+      description: |
+        Maps to `TaskProvider.update_task`. Only fields present in the body
+        are modified; absent fields are untouched. An explicit empty string
+        CLEARS a text field — this distinction is load-bearing for the CLI's
+        modify-if-passed contract.
+      tags: [tasks]
+      parameters: [{ $ref: "#/components/parameters/taskId" }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: string }
+                description: { type: string }
+                status:
+                  type: string
+                  description: Status name; must exist on the task's list.
+                priority:
+                  $ref: "#/components/schemas/PriorityWrite"
+                due_date:
+                  $ref: "#/components/schemas/EpochMillis"
+                assignees:
+                  type: array
+                  items: { type: string }
+                  description: Replaces the full assignee set.
+                archived: { type: boolean }
+      responses:
+        "200":
+          description: The updated task.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Task" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
+    delete:
+      operationId: deleteTask
+      summary: Delete a task (optional capability `delete_tasks`)
+      description: Maps to `TaskProvider.delete_task`.
+      tags: [tasks]
+      parameters: [{ $ref: "#/components/parameters/taskId" }]
+      responses:
+        "204":
+          description: Deleted.
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /tasks/{taskId}/comments:
+    get:
+      operationId: listTaskComments
+      summary: List comments on a task
+      description: Maps to `TaskProvider.get_task_comments`. Oldest first.
+      tags: [comments]
+      parameters: [{ $ref: "#/components/parameters/taskId" }]
+      responses:
+        "200":
+          description: Comments.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data]
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: "#/components/schemas/Comment" }
+                  count: { type: integer }
+        "404": { $ref: "#/components/responses/NotFound" }
+    post:
+      operationId: createComment
+      summary: Add a comment to a task
+      description: Maps to `TaskProvider.create_comment`.
+      tags: [comments]
+      parameters: [{ $ref: "#/components/parameters/taskId" }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [comment_text]
+              properties:
+                comment_text: { type: string }
+      responses:
+        "201":
+          description: The created comment.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Comment" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: Opaque API token. How tokens are minted is backend-specific.
+
+  parameters:
+    workspaceId:
+      name: workspaceId
+      in: path
+      required: true
+      schema: { type: string }
+    spaceId:
+      name: spaceId
+      in: path
+      required: true
+      schema: { type: string }
+    folderId:
+      name: folderId
+      in: path
+      required: true
+      schema: { type: string }
+    listId:
+      name: listId
+      in: path
+      required: true
+      schema: { type: string }
+    taskId:
+      name: taskId
+      in: path
+      required: true
+      schema: { type: string }
+
+  requestBodies:
+    CreateList:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [name]
+            properties:
+              name: { type: string }
+              content:
+                type: string
+                description: List description.
+              due_date:
+                $ref: "#/components/schemas/EpochMillis"
+              priority:
+                $ref: "#/components/schemas/PriorityWrite"
+              assignee:
+                type: string
+                description: Default assignee user ID.
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid credential.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    NotFound:
+      description: Resource does not exist (or caller cannot see it).
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    BadRequest:
+      description: Validation failure or unsupported capability.
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+
+  schemas:
+    EpochMillis:
+      type: string
+      pattern: "^[0-9]+$"
+      description: Epoch milliseconds encoded as a string, e.g. "1781059930000".
+
+    PriorityWrite:
+      type: integer
+      enum: [1, 2, 3, 4]
+      description: "1=urgent, 2=high, 3=normal, 4=low."
+
+    Capabilities:
+      type: object
+      description: |
+        Optional-capability flags. Omitted keys default to true. Maps to the
+        graceful-degradation behavior of partial adapters (see PlankaProvider).
+      properties:
+        backend:
+          type: string
+          description: Human-readable backend name, e.g. "planka".
+        version:
+          type: string
+          description: Backend/shim version string.
+        folders:
+          type: boolean
+          description: Real folder support. False = folders are synthetic or absent.
+        search:
+          type: boolean
+          description: Workspace-wide task search.
+        delete_tasks:
+          type: boolean
+        comments:
+          type: boolean
+      additionalProperties: true
+
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              description: Machine-readable error class.
+              enum:
+                - authentication
+                - authorization
+                - not_found
+                - validation
+                - rate_limit
+                - unsupported
+                - server
+            message: { type: string }
+          additionalProperties: true
+      additionalProperties: true
+
+    User:
+      type: object
+      required: [id, username, email]
+      properties:
+        id: { type: integer }
+        username: { type: string }
+        email: { type: string }
+        color: { type: [string, "null"] }
+        profilePicture: { type: [string, "null"] }
+        role: { type: [integer, string, "null"] }
+      additionalProperties: true
+
+    StatusInfo:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          description: Status name, e.g. "in progress".
+        color: { type: [string, "null"] }
+        type:
+          type: [string, "null"]
+          description: '"open", "custom", "done", or "closed".'
+        orderindex: { type: [integer, "null"] }
+      additionalProperties: true
+
+    PriorityInfo:
+      type: object
+      properties:
+        id: { type: [string, "null"] }
+        priority:
+          type: [string, "null"]
+          description: Priority name or numeric string ("1"-"4").
+        color: { type: [string, "null"] }
+        orderindex: { type: [string, "null"] }
+      additionalProperties: true
+
+    Tag:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        tag_fg: { type: [string, "null"] }
+        tag_bg: { type: [string, "null"] }
+      additionalProperties: true
+
+    Assignee:
+      type: object
+      required: [id, username]
+      properties:
+        id: { type: integer }
+        username: { type: string }
+        color: { type: [string, "null"] }
+        email: { type: [string, "null"] }
+      additionalProperties: true
+
+    Workspace:
+      type: object
+      required: [id, name, color]
+      properties:
+        id: { type: string }
+        name: { type: string }
+        color:
+          type: string
+          description: Hex color; synthesize a constant if the backend has none.
+        avatar: { type: [string, "null"] }
+        members:
+          type: array
+          items:
+            type: object
+            required: [user]
+            properties:
+              user: { $ref: "#/components/schemas/User" }
+            additionalProperties: true
+      additionalProperties: true
+
+    WorkspaceCollection:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: array
+          items: { $ref: "#/components/schemas/Workspace" }
+        count: { type: integer }
+      additionalProperties: true
+
+    Space:
+      type: object
+      required: [id, name, private, multiple_assignees]
+      properties:
+        id: { type: string }
+        name: { type: string }
+        private: { type: boolean }
+        statuses:
+          type: array
+          description: Statuses available to lists in this space (may be empty if statuses are per-list).
+          items: { $ref: "#/components/schemas/StatusInfo" }
+        multiple_assignees: { type: boolean }
+        features:
+          type: object
+          additionalProperties: true
+        archived: { type: boolean, default: false }
+      additionalProperties: true
+
+    Folder:
+      type: object
+      required: [id, name, orderindex, override_statuses, hidden, space, task_count]
+      properties:
+        id:
+          type: string
+          description: Synthetic folders use `folder_<spaceId>`.
+        name: { type: string }
+        orderindex: { type: integer }
+        override_statuses: { type: boolean }
+        hidden: { type: boolean }
+        space: { $ref: "#/components/schemas/SpaceRef" }
+        task_count:
+          type: string
+          description: Stringified count (ClickUp wire-format wart; kept for compatibility).
+        archived: { type: boolean, default: false }
+        lists:
+          type: array
+          items: { $ref: "#/components/schemas/List" }
+      additionalProperties: true
+
+    SpaceRef:
+      type: object
+      required: [id]
+      properties:
+        id: { type: string }
+        name: { type: [string, "null"] }
+      additionalProperties: true
+
+    FolderRef:
+      type: object
+      required: [id]
+      properties:
+        id: { type: string }
+        name: { type: [string, "null"] }
+      additionalProperties: true
+
+    ListRef:
+      type: object
+      required: [id]
+      properties:
+        id: { type: string }
+        name: { type: [string, "null"] }
+      additionalProperties: true
+
+    List:
+      type: object
+      required: [id, name]
+      properties:
+        id: { type: string }
+        name: { type: string }
+        orderindex: { type: [integer, "null"] }
+        content:
+          type: [string, "null"]
+          description: List description.
+        status: { oneOf: [{ $ref: "#/components/schemas/StatusInfo" }, { type: "null" }] }
+        priority: { oneOf: [{ $ref: "#/components/schemas/PriorityInfo" }, { type: "null" }] }
+        task_count: { type: [integer, "null"] }
+        due_date: { oneOf: [{ $ref: "#/components/schemas/EpochMillis" }, { type: "null" }] }
+        start_date: { oneOf: [{ $ref: "#/components/schemas/EpochMillis" }, { type: "null" }] }
+        folder: { oneOf: [{ $ref: "#/components/schemas/FolderRef" }, { type: "null" }] }
+        space: { oneOf: [{ $ref: "#/components/schemas/SpaceRef" }, { type: "null" }] }
+        archived: { type: boolean, default: false }
+        statuses:
+          type: array
+          description: RECOMMENDED extra field — the statuses tasks in this list can take, in workflow order.
+          items: { $ref: "#/components/schemas/StatusInfo" }
+      additionalProperties: true
+
+    ListCollection:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: array
+          items: { $ref: "#/components/schemas/List" }
+        count: { type: integer }
+      additionalProperties: true
+
+    Task:
+      type: object
+      required: [id, name]
+      properties:
+        id: { type: string }
+        custom_id: { type: [string, "null"] }
+        name: { type: string }
+        text_content: { type: [string, "null"] }
+        description: { type: [string, "null"] }
+        status: { oneOf: [{ $ref: "#/components/schemas/StatusInfo" }, { type: "null" }] }
+        orderindex: { type: [string, "null"] }
+        date_created: { oneOf: [{ $ref: "#/components/schemas/EpochMillis" }, { type: "null" }] }
+        date_updated: { oneOf: [{ $ref: "#/components/schemas/EpochMillis" }, { type: "null" }] }
+        date_closed: { oneOf: [{ $ref: "#/components/schemas/EpochMillis" }, { type: "null" }] }
+        date_done: { oneOf: [{ $ref: "#/components/schemas/EpochMillis" }, { type: "null" }] }
+        archived: { type: boolean, default: false }
+        creator: { oneOf: [{ $ref: "#/components/schemas/User" }, { type: "null" }] }
+        assignees:
+          type: array
+          items: { $ref: "#/components/schemas/Assignee" }
+        tags:
+          type: array
+          items: { $ref: "#/components/schemas/Tag" }
+        parent:
+          type: [string, "null"]
+          description: Parent task ID for subtasks.
+        priority: { oneOf: [{ $ref: "#/components/schemas/PriorityInfo" }, { type: "null" }] }
+        due_date: { oneOf: [{ $ref: "#/components/schemas/EpochMillis" }, { type: "null" }] }
+        start_date: { oneOf: [{ $ref: "#/components/schemas/EpochMillis" }, { type: "null" }] }
+        time_estimate: { type: [integer, "null"] }
+        time_spent: { type: [integer, "null"] }
+        team_id: { type: [string, "null"] }
+        url:
+          type: [string, "null"]
+          description: Deep link into the backend's own UI, if it has one.
+        list: { oneOf: [{ $ref: "#/components/schemas/ListRef" }, { type: "null" }] }
+        folder: { oneOf: [{ $ref: "#/components/schemas/FolderRef" }, { type: "null" }] }
+        space: { oneOf: [{ $ref: "#/components/schemas/SpaceRef" }, { type: "null" }] }
+        comment_count:
+          type: integer
+          description: RECOMMENDED extra field — number of comments on the task.
+      additionalProperties: true
+
+    TaskCollection:
+      type: object
+      required: [data]
+      properties:
+        data:
+          type: array
+          items: { $ref: "#/components/schemas/Task" }
+        count: { type: integer }
+      additionalProperties: true
+
+    Comment:
+      type: object
+      required: [id, comment_text, user, date]
+      properties:
+        id: { type: string }
+        comment:
+          type: array
+          description: Rich-text segments; servers without rich text return one plain segment.
+          items:
+            type: object
+            additionalProperties: true
+        comment_text:
+          type: string
+          description: Plain-text body.
+        user: { $ref: "#/components/schemas/User" }
+        date: { $ref: "#/components/schemas/EpochMillis" }
+        resolved: { type: boolean, default: false }
+      additionalProperties: true

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -24,11 +24,18 @@ info:
     ## Conventions
 
     - **IDs** are opaque strings, except user IDs which are integers.
-    - **Timestamps** are epoch-milliseconds encoded as strings
-      (e.g. `"1781059930000"`), matching ClickUp's wire format. ISO 8601 is
-      NOT accepted.
+    - **Timestamps** in request/response BODIES are epoch-milliseconds
+      encoded as strings (e.g. `"1781059930000"`), matching ClickUp's wire
+      format. ISO 8601 is NOT accepted. Date-filter QUERY parameters are
+      plain integers (epoch-ms) — this asymmetry mirrors what the CLI
+      actually sends.
     - **Priority** is written as an integer 1-4 (1=urgent, 2=high, 3=normal,
       4=low) and read back as a `PriorityInfo` object.
+    - **User IDs** are integers in read responses but are sent as
+      stringified integers in write bodies (`assignees`, `assignee`) — this
+      asymmetry mirrors the CLI's wire behavior.
+    - **Rate limiting**: any endpoint MAY return `429` with a `Retry-After`
+      header and error code `rate_limit`, even where not listed explicitly.
     - **Collections** are returned as `{"data": [...], "count": N}`.
     - **All object schemas are open**: servers MAY include extra fields and
       clients MUST ignore unknown fields (the CLI's pydantic models use
@@ -178,7 +185,10 @@ paths:
           schema: { type: string }
         - name: assignees
           in: query
-          description: Restrict to tasks assigned to any of these user IDs.
+          description: |
+            Restrict to tasks assigned to any of these user IDs (stringified
+            integers). Servers MAY ignore this filter — the CLI currently
+            applies assignee filtering client-side and does not rely on it.
           schema:
             type: array
             items: { type: string }
@@ -192,6 +202,7 @@ paths:
               schema: { $ref: "#/components/schemas/TaskCollection" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "404": { $ref: "#/components/responses/NotFound" }
+        "429": { $ref: "#/components/responses/RateLimited" }
 
   /spaces/{spaceId}:
     get:
@@ -385,8 +396,11 @@ paths:
           explode: true
         - name: include_closed
           in: query
-          description: Include tasks in closed/done statuses. Default false.
-          schema: { type: boolean, default: false }
+          description: |
+            Include tasks in closed/done statuses. When OMITTED, closed tasks
+            ARE included (matching existing adapter behavior); the CLI sends
+            an explicit `false` when it wants them excluded.
+          schema: { type: boolean, default: true }
         - name: date_created_gt
           in: query
           description: Epoch-ms lower bound on creation time.
@@ -407,6 +421,7 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/TaskCollection" }
         "404": { $ref: "#/components/responses/NotFound" }
+        "429": { $ref: "#/components/responses/RateLimited" }
     post:
       operationId: createTask
       summary: Create a task
@@ -435,7 +450,9 @@ paths:
                 assignees:
                   type: array
                   items: { type: string }
-                  description: User IDs to assign.
+                  description: |
+                    User IDs to assign, as stringified integers (read
+                    responses return integer user IDs).
       responses:
         "201":
           description: The created task.
@@ -444,6 +461,7 @@ paths:
               schema: { $ref: "#/components/schemas/Task" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "404": { $ref: "#/components/responses/NotFound" }
+        "429": { $ref: "#/components/responses/RateLimited" }
 
   /tasks/{taskId}:
     get:
@@ -467,6 +485,9 @@ paths:
         are modified; absent fields are untouched. An explicit empty string
         CLEARS a text field — this distinction is load-bearing for the CLI's
         modify-if-passed contract.
+
+        There is no server-side append: the CLI's `--description-append` is
+        a client-side read-modify-write that sends the full new description.
       tags: [tasks]
       parameters: [{ $ref: "#/components/parameters/taskId" }]
       requestBody:
@@ -488,7 +509,9 @@ paths:
                 assignees:
                   type: array
                   items: { type: string }
-                  description: Replaces the full assignee set.
+                  description: |
+                    Replaces the full assignee set. User IDs as stringified
+                    integers (read responses return integer user IDs).
                 archived: { type: boolean }
       responses:
         "200":
@@ -608,11 +631,22 @@ components:
                 $ref: "#/components/schemas/PriorityWrite"
               assignee:
                 type: string
-                description: Default assignee user ID.
+                description: Default assignee user ID (stringified integer).
 
   responses:
     Unauthorized:
-      description: Missing or invalid credential.
+      description: |
+        Missing or invalid credential. The JSON body MAY be omitted — clients
+        treat a bare 401 status as "credential invalid".
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    RateLimited:
+      description: Rate limit exceeded. Retry after the indicated delay.
+      headers:
+        Retry-After:
+          description: Seconds to wait before retrying.
+          schema: { type: integer }
       content:
         application/json:
           schema: { $ref: "#/components/schemas/Error" }
@@ -657,8 +691,6 @@ components:
           type: boolean
           description: Workspace-wide task search.
         delete_tasks:
-          type: boolean
-        comments:
           type: boolean
       additionalProperties: true
 
@@ -729,6 +761,9 @@ components:
         name: { type: string }
         tag_fg: { type: [string, "null"] }
         tag_bg: { type: [string, "null"] }
+        creator:
+          type: [integer, "null"]
+          description: User ID of the tag creator.
       additionalProperties: true
 
     Assignee:
@@ -846,6 +881,9 @@ components:
           description: List description.
         status: { oneOf: [{ $ref: "#/components/schemas/StatusInfo" }, { type: "null" }] }
         priority: { oneOf: [{ $ref: "#/components/schemas/PriorityInfo" }, { type: "null" }] }
+        assignee:
+          oneOf: [{ $ref: "#/components/schemas/User" }, { type: "null" }]
+          description: Default assignee for the list.
         task_count: { type: [integer, "null"] }
         due_date: { oneOf: [{ $ref: "#/components/schemas/EpochMillis" }, { type: "null" }] }
         start_date: { oneOf: [{ $ref: "#/components/schemas/EpochMillis" }, { type: "null" }] }


### PR DESCRIPTION
## Summary
- **`spec/openapi.yaml`** (validated with openapi-spec-validator): the HTTP projection of the `TaskProvider` protocol, so non-Python adopters can back the CLI by implementing a small REST surface. Key design calls (full rationale in `spec/README.md`):
  - The Python protocol stays the source of truth; the spec is derived
  - Folders/search/delete are **optional capabilities** with a `GET /capabilities` discovery endpoint (formalizing PlankaProvider's degradation patterns)
  - Wire format stays ClickUp-shaped (epoch-ms strings, string IDs, open schemas) because the pydantic models already speak it
  - Request bodies/filters match the CLI's actual call sites (inventoried every provider call in `clickup/cli/`); `raw_request` is explicitly out of scope
  - `PATCH /tasks/{id}` contractually preserves modify-if-passed semantics ("" clears, absent leaves alone)
- **Agent-facing docs overhaul**: new `docs/architecture.md` (system map), `docs/backends.md` (spin-up + env vars + verification for every provider, incl. zero-infra `json` and both live/local Planka), `docs/writing-an-adapter.md` (concept-mapping-first adapter guide with degradation patterns)
- **AGENT.md** gains a "Docs map" table and a "Backends" section; README links the spec

## Test plan
- [x] `openapi-spec-validator spec/openapi.yaml` — OK
- [x] `just fc` — 504 passed, coverage 90.6%
- [ ] Follow-up (tracked in spec/README.md status): `GenericProvider` adapter + conformance test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)