### PR TITLE
JsonProvider: enrich Folder.lists and task_count at read time

### DIFF
--- a/clickup/core/json_provider.py
+++ b/clickup/core/json_provider.py
@@ -232,6 +232,24 @@ class JsonProvider:
             data["comment_count"] = len(store.get("comments", {}).get(task["id"], []))
         return Task(**data)
 
+    def _folder_model(self, folder: dict[str, Any], store: dict[str, Any]) -> Folder:
+        """Materialise a Folder model, enriching child lists and task_count at read time.
+
+        Stored ``task_count`` / ``lists`` values are ignored — both are
+        recomputed from the current store so reads always reflect the latest
+        state.  This mirrors the ``_task_model`` comment_count enrichment
+        pattern (commit 1ebe042).
+        """
+        data = deepcopy(folder)
+        folder_id = data["id"]
+        child_lists = [lst for lst in store.get("lists", []) if lst.get("folder_id") == folder_id]
+        data["lists"] = child_lists
+        total_tasks = sum(
+            len([t for t in store.get("tasks", []) if t.get("list", {}).get("id") == lst["id"]]) for lst in child_lists
+        )
+        data["task_count"] = str(total_tasks)
+        return Folder(**data)
+
     def _resolve_status(self, list_data: dict[str, Any], name: str) -> dict[str, Any]:
         """Look up a status by name on the given list, falling back to its space.
 
@@ -308,16 +326,18 @@ class JsonProvider:
         raise NotFoundError(f"Space not found: {space_id}")
 
     async def get_folders(self, space_id: str) -> list[Folder]:
+        store = self._load()
         return [
-            Folder(**folder)
-            for folder in self._load().get("folders", [])
+            self._folder_model(folder, store)
+            for folder in store.get("folders", [])
             if folder.get("space", {}).get("id") == space_id
         ]
 
     async def get_folder(self, folder_id: str) -> Folder:
-        for folder in self._load().get("folders", []):
+        store = self._load()
+        for folder in store.get("folders", []):
             if folder["id"] == folder_id:
-                return Folder(**folder)
+                return self._folder_model(folder, store)
         raise NotFoundError(f"Folder not found: {folder_id}")
 
     async def create_folder(self, space_id: str, name: str, **kwargs: Any) -> Folder:
@@ -339,7 +359,7 @@ class JsonProvider:
         }
         store.setdefault("folders", []).append(folder)
         self._save(store)
-        return Folder(**folder)
+        return self._folder_model(folder, store)
 
     async def get_lists(self, folder_id: str) -> list[ClickUpList]:
         return [ClickUpList(**item) for item in self._load().get("lists", []) if item.get("folder_id") == folder_id]

--- a/tests/unit/test_folder_enrichment.py
+++ b/tests/unit/test_folder_enrichment.py
@@ -1,0 +1,93 @@
+"""Unit tests for read-time folder enrichment in the JSON provider.
+
+Validates that ``get_folder`` / ``get_folders`` populate child lists and
+compute ``task_count`` from live store data, so reads always reflect the
+latest state regardless of what was stored at write time.
+"""
+
+import pytest
+
+from clickup.core import Config
+from clickup.core.json_provider import JsonProvider, write_seed_store
+
+
+@pytest.fixture()
+def provider(tmp_path, monkeypatch):
+    """Return a ready-to-use JsonProvider backed by a tmp seed store."""
+    monkeypatch.setenv("CLICKUP_CONFIG_PATH", str(tmp_path / "config.json"))
+    store_path = tmp_path / "mock-store.json"
+    write_seed_store(store_path)
+    config = Config()
+    config.set("json_store_path", str(store_path))
+    return JsonProvider(config)
+
+
+@pytest.mark.asyncio
+async def test_folder_get_reflects_newly_created_child_list(provider):
+    """After creating a list inside a folder, ``get_folder`` includes it."""
+    async with provider as p:
+        # Seed folder starts with two child lists (list_inbox, list_active).
+        folder = await p.get_folder("folder_daily")
+        assert len(folder.lists) == 2
+        original_ids = {lst.id for lst in folder.lists}
+
+        # Create a new list inside the same folder.
+        new_list = await p.create_list("folder_daily", "Backlog")
+
+        # Re-fetch: the new list must appear.
+        folder = await p.get_folder("folder_daily")
+        assert len(folder.lists) == 3
+        refreshed_ids = {lst.id for lst in folder.lists}
+        assert new_list.id in refreshed_ids
+        assert original_ids < refreshed_ids
+
+
+@pytest.mark.asyncio
+async def test_folder_task_count_rolls_up_after_task_creation(provider):
+    """``task_count`` sums tasks across all child lists, stringified."""
+    async with provider as p:
+        # Seed store: list_inbox has 3 tasks, list_active has 2 → total 5.
+        folder = await p.get_folder("folder_daily")
+        assert folder.task_count == "5"
+
+        # Add a task to list_inbox.
+        await p.create_task("list_inbox", "Extra task")
+        folder = await p.get_folder("folder_daily")
+        assert folder.task_count == "6"
+
+        # Add a task to list_active.
+        await p.create_task("list_active", "Another extra")
+        folder = await p.get_folder("folder_daily")
+        assert folder.task_count == "7"
+
+
+@pytest.mark.asyncio
+async def test_get_folders_enriches_all_returned_folders(provider):
+    """``get_folders`` enriches every folder, not just the first."""
+    async with provider as p:
+        # Create a second folder with a list and a task.
+        new_folder = await p.create_folder("space_ops", "Projects")
+        new_list = await p.create_list(new_folder.id, "Sprint")
+        await p.create_task(new_list.id, "Ship it")
+
+        folders = await p.get_folders("space_ops")
+        by_id = {f.id: f for f in folders}
+
+        daily = by_id["folder_daily"]
+        assert len(daily.lists) == 2
+        assert daily.task_count == "5"  # unchanged seed data
+
+        projects = by_id[new_folder.id]
+        assert len(projects.lists) == 1
+        assert projects.lists[0].id == new_list.id
+        assert projects.task_count == "1"
+
+
+@pytest.mark.asyncio
+async def test_empty_folder_has_zero_task_count(provider):
+    """A folder with no child lists reports task_count '0'."""
+    async with provider as p:
+        empty = await p.create_folder("space_ops", "Empty")
+        folder = await p.get_folder(empty.id)
+        assert folder.lists == []
+        assert folder.task_count == "0"


### PR DESCRIPTION
## Summary
- Folders returned by the local JSON provider now reflect reality: `lists` is populated with child lists and `task_count` rolls up tasks across them, recomputed at read time (issue #35 item 2)
- Same read-time enrichment pattern as the existing `comment_count` annotation; store format and write paths unchanged

## Test plan
- [x] 4 new unit tests (new child list visible via `folder get`, task_count rollup, enrichment on `get_folders`, empty folder)
- [x] `just fc` — 508 passed, coverage 90.63%

Part of #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)