### PR TITLE
task search: full filter-matrix symmetry with list/mine; optional query

### DIFF
--- a/clickup/cli/commands/task.py
+++ b/clickup/cli/commands/task.py
@@ -290,6 +290,31 @@ def _sort_tasks_locally(tasks: list[Any], field: str | None, descending: bool) -
     return present + missing
 
 
+def _apply_task_filters(
+    tasks: list[Any],
+    *,
+    statuses: set[str] | None = None,
+    updated_since_ms: int | None = None,
+    open_only: bool = False,
+    sort_field: str | None = None,
+    sort_descending: bool = False,
+) -> list[Any]:
+    """Shared client-side post-filter + sort pipeline.
+
+    Used by ``task list``, ``task mine``, and ``task search`` so the
+    ``--status``/``--sort``/``--updated-since``/``--open-only`` filters
+    behave identically everywhere.
+    """
+    if statuses:
+        tasks = [t for t in tasks if t.status and t.status.status and t.status.status.lower() in statuses]
+    if updated_since_ms is not None:
+        tasks = [t for t in tasks if t.date_updated and int(t.date_updated) >= updated_since_ms]
+    if open_only:
+        tasks = _filter_open_only(tasks)
+    tasks = _sort_tasks_locally(tasks, sort_field, sort_descending)
+    return tasks
+
+
 @app.command("list")
 def list_tasks(
     list_id: str | None = typer.Option(None, "--list-id", "-l", help="List ID to get tasks from"),
@@ -343,7 +368,11 @@ def list_tasks(
         ),
     ),
 ) -> None:
-    """List tasks from a ClickUp list."""
+    """List tasks from a ClickUp list.
+
+    Supports the same --status/--sort/--updated-since/--open-only filters
+    as ``task mine`` and ``task search``.
+    """
     order_by, descending = _parse_sort(sort, reverse)
 
     async def _list_tasks() -> None:
@@ -385,14 +414,14 @@ def list_tasks(
                     if include_source:
                         list_tasks_result = [_annotate_source_list(task, list_id_to_use) for task in list_tasks_result]
                     tasks.extend(list_tasks_result)
-                # Filter closed tasks before sorting/limiting so --open-only
-                # interacts predictably with --limit.
-                if open_only:
-                    tasks = _filter_open_only(tasks)
-                # Globally sort, then limit. Doing it in this order is what
-                # makes --sort priority --all-lists produce a true priority
-                # ranking instead of per-list batches.
-                tasks = _sort_tasks_locally(tasks, order_by, descending)
+                # Client-side filter + sort pipeline. open_only and sort are
+                # applied here (status/date filters already went to the API).
+                tasks = _apply_task_filters(
+                    tasks,
+                    open_only=open_only,
+                    sort_field=order_by,
+                    sort_descending=descending,
+                )
                 tasks = tasks[:limit]
                 render_tasks(tasks, brief=brief)
                 if not tasks:
@@ -470,7 +499,9 @@ def my_tasks(
 
     Searches across the workspace for tasks assigned to you. Uses the default
     workspace from config, or auto-detects if you belong to exactly one workspace.
-    Supports the same filter/sort/projection flags as ``task list``.
+
+    Supports the same --status/--sort/--updated-since/--open-only filters
+    as ``task list`` and ``task search``.
     """
     order_by, descending = _parse_sort(sort, reverse)
     status_filter = {s.lower() for s in _split_csv(status)} if status else None
@@ -491,19 +522,15 @@ def my_tasks(
                     **{"assignees[]": [str(user.id)]},
                 )
 
-                # Post-filter client-side. search_tasks doesn't accept the rich
-                # filter set get_tasks does, so we apply them here for parity
-                # with `task list`.
-                if status_filter:
-                    tasks = [
-                        t for t in tasks if t.status and t.status.status and t.status.status.lower() in status_filter
-                    ]
-                if updated_since_ms is not None:
-                    tasks = [t for t in tasks if t.date_updated and int(t.date_updated) >= updated_since_ms]
-                if open_only:
-                    tasks = _filter_open_only(tasks)
-
-                tasks = _sort_tasks_locally(tasks, order_by, descending)
+                # Client-side filter + sort via shared pipeline.
+                tasks = _apply_task_filters(
+                    tasks,
+                    statuses=status_filter,
+                    updated_since_ms=updated_since_ms,
+                    open_only=open_only,
+                    sort_field=order_by,
+                    sort_descending=descending,
+                )
                 tasks = tasks[:limit]
                 render_tasks(tasks, brief=brief)
                 if not tasks:
@@ -895,23 +922,50 @@ def delete_task(
 
 @app.command("search")
 def search_tasks(
-    query: str | None = typer.Option(None, "--query", "-q", help="Search query"),
+    query: str | None = typer.Option(
+        None,
+        "--query",
+        "-q",
+        help="Search query. Omit for workspace-wide enumeration (returns all tasks).",
+    ),
     workspace_id: str | None = typer.Option(None, "--workspace-id", "-w", help="Workspace ID to search in"),
     team_id: str | None = typer.Option(None, "--team-id", "-t", help="Team ID (alias for workspace-id)"),
+    status: str | None = typer.Option(None, "--status", "-s", help="Filter by status; comma-separated values allowed"),
+    sort: str | None = typer.Option(
+        None,
+        "--sort",
+        "--order-by",
+        help=(
+            "Sort by: created, updated, due_date, priority. Direction: 'priority:desc', '-priority', '+priority'. "
+            "Priority is numeric (1=urgent..4=low), so 'priority' (asc) puts urgent first."
+        ),
+    ),
+    reverse: bool = typer.Option(False, "--reverse", help="Sort descending."),
+    updated_since: str | None = typer.Option(None, "--updated-since", help="Updated after relative time, e.g. 7d"),
+    open_only: bool = typer.Option(
+        False,
+        "--open-only",
+        "--open",
+        help="Hide tasks whose status type is 'closed'.",
+    ),
+    limit: int = typer.Option(50, "--limit", help="Maximum number of tasks to show"),
     brief: bool = typer.Option(False, "--brief", help="Return a stripped projection (see `task list --brief`)."),
 ) -> None:
     """Search for tasks across the workspace.
 
     ClickUp search performs fuzzy/full-text matching across multiple task
     fields (name, description, comments, custom fields, etc.), not just the
-    task name. Results are ranked by relevance.
+    task name. Results are ranked by relevance. Omit --query for a bare
+    workspace-wide enumeration (all tasks).
+
+    Supports the same --status/--sort/--updated-since/--open-only filters
+    as ``task list`` and ``task mine``.
     """
+    order_by, descending = _parse_sort(sort, reverse)
+    status_filter = {s.lower() for s in _split_csv(status)} if status else None
+    updated_since_ms = _epoch_ms(updated_since) if updated_since else None
 
     async def _search_tasks() -> None:
-        if not query:
-            render_error("Error: Search query is required.", hint="Use --query to specify the search terms")
-            raise typer.Exit(1)
-
         # Use either workspace_id or team_id (they're the same thing)
         id_to_use = workspace_id or team_id
         if not id_to_use:
@@ -926,10 +980,23 @@ def search_tasks(
 
         try:
             async with await get_client() as client:
-                tasks = await client.search_tasks(id_to_use, query)
+                tasks = await client.search_tasks(id_to_use, query or "")
+                # Client-side filter + sort via shared pipeline.
+                tasks = _apply_task_filters(
+                    tasks,
+                    statuses=status_filter,
+                    updated_since_ms=updated_since_ms,
+                    open_only=open_only,
+                    sort_field=order_by,
+                    sort_descending=descending,
+                )
+                tasks = tasks[:limit]
                 render_tasks(tasks, brief=brief)
                 if not tasks:
-                    render_message(f"No tasks found matching '{query}'", "warn")
+                    if query:
+                        render_message(f"No tasks found matching '{query}'", "warn")
+                    else:
+                        render_message("No tasks found.", "warn")
                 else:
                     render_message(f"Found {len(tasks)} task(s)", "info")
 

--- a/tests/integration/test_task_coverage.py
+++ b/tests/integration/test_task_coverage.py
@@ -197,10 +197,18 @@ def test_task_search_empty(mock_get_client):
     assert "No tasks found" in result.stderr
 
 
-def test_task_search_no_query_errors():
+@patch("clickup.cli.commands.task.get_client")
+def test_task_search_bare_enumerates_all(mock_get_client):
+    """Omitting --query is valid: workspace-wide enumeration (empty query returns all)."""
+    mock_client = AsyncMock()
+    mock_client.search_tasks.return_value = [Task(id="t1", name="All")]
+    mock_get_client.return_value = _ctx(mock_client)
+
     result = runner.invoke(app, ["task", "search", "--workspace-id", "W1"])
-    assert result.exit_code != 0
-    assert "query" in result.stderr.lower()
+    assert result.exit_code == 0
+    assert "All" in result.output
+    # Verify empty string was passed to the adapter
+    mock_client.search_tasks.assert_awaited_once_with("W1", "")
 
 
 def test_task_search_no_workspace_errors():

--- a/tests/unit/test_apply_task_filters.py
+++ b/tests/unit/test_apply_task_filters.py
@@ -1,0 +1,356 @@
+"""Unit tests for ``_apply_task_filters`` and the ``task search`` filter flags.
+
+These pin the shared filter pipeline's contract directly, then exercise the
+new search flags via CliRunner against mocked providers.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+from typer.testing import CliRunner
+
+from clickup.cli.commands.task import _apply_task_filters
+from clickup.cli.main import app
+from clickup.core.models import PriorityInfo, StatusInfo, Task
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx(client: AsyncMock) -> AsyncMock:
+    cm = AsyncMock()
+    cm.__aenter__.return_value = client
+    return cm
+
+
+def _make_task(
+    task_id: str,
+    name: str,
+    status: str = "to do",
+    status_type: str = "open",
+    priority: str | None = None,
+    date_updated: str = "1700000001000",
+) -> Mock:
+    """Build a lightweight mock task for filter tests."""
+    t = Mock()
+    t.id = task_id
+    t.name = name
+    t.status = StatusInfo(status=status, type=status_type)
+    t.priority = PriorityInfo(priority=priority) if priority else None
+    t.date_created = date_updated
+    t.date_updated = date_updated
+    t.due_date = None
+    t.assignees = []
+    t.description = ""
+    return t
+
+
+# ---------------------------------------------------------------------------
+# _apply_task_filters unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplyTaskFiltersStatus:
+    def test_filters_by_status(self):
+        tasks = [
+            _make_task("1", "A", status="to do"),
+            _make_task("2", "B", status="in progress"),
+            _make_task("3", "C", status="complete"),
+        ]
+        result = _apply_task_filters(tasks, statuses={"to do"})
+        assert [t.id for t in result] == ["1"]
+
+    def test_status_filter_is_case_insensitive(self):
+        tasks = [_make_task("1", "A", status="In Progress")]
+        result = _apply_task_filters(tasks, statuses={"in progress"})
+        assert [t.id for t in result] == ["1"]
+
+    def test_multiple_statuses(self):
+        tasks = [
+            _make_task("1", "A", status="to do"),
+            _make_task("2", "B", status="in progress"),
+            _make_task("3", "C", status="complete"),
+        ]
+        result = _apply_task_filters(tasks, statuses={"to do", "complete"})
+        assert {t.id for t in result} == {"1", "3"}
+
+    def test_none_statuses_no_filter(self):
+        tasks = [_make_task("1", "A"), _make_task("2", "B")]
+        result = _apply_task_filters(tasks, statuses=None)
+        assert len(result) == 2
+
+
+class TestApplyTaskFiltersUpdatedSince:
+    def test_filters_by_updated_since(self):
+        tasks = [
+            _make_task("1", "Old", date_updated="1000"),
+            _make_task("2", "New", date_updated="2000"),
+        ]
+        result = _apply_task_filters(tasks, updated_since_ms=1500)
+        assert [t.id for t in result] == ["2"]
+
+    def test_none_updated_since_no_filter(self):
+        tasks = [_make_task("1", "A"), _make_task("2", "B")]
+        result = _apply_task_filters(tasks, updated_since_ms=None)
+        assert len(result) == 2
+
+
+class TestApplyTaskFiltersOpenOnly:
+    def test_open_only_drops_closed(self):
+        tasks = [
+            _make_task("1", "Open", status="to do", status_type="open"),
+            _make_task("2", "Closed", status="complete", status_type="closed"),
+        ]
+        result = _apply_task_filters(tasks, open_only=True)
+        assert [t.id for t in result] == ["1"]
+
+    def test_open_only_false_keeps_all(self):
+        tasks = [
+            _make_task("1", "Open", status="to do", status_type="open"),
+            _make_task("2", "Closed", status="complete", status_type="closed"),
+        ]
+        result = _apply_task_filters(tasks, open_only=False)
+        assert len(result) == 2
+
+
+class TestApplyTaskFiltersSort:
+    def test_sorts_by_priority_asc(self):
+        tasks = [
+            _make_task("1", "Low", priority="4"),
+            _make_task("2", "Urgent", priority="1"),
+            _make_task("3", "High", priority="2"),
+        ]
+        result = _apply_task_filters(tasks, sort_field="priority", sort_descending=False)
+        assert [t.id for t in result] == ["2", "3", "1"]
+
+    def test_sorts_by_priority_desc(self):
+        tasks = [
+            _make_task("1", "Low", priority="4"),
+            _make_task("2", "Urgent", priority="1"),
+        ]
+        result = _apply_task_filters(tasks, sort_field="priority", sort_descending=True)
+        assert [t.id for t in result] == ["1", "2"]
+
+    def test_sorts_by_updated(self):
+        tasks = [
+            _make_task("1", "Old", date_updated="3000"),
+            _make_task("2", "New", date_updated="1000"),
+        ]
+        result = _apply_task_filters(tasks, sort_field="updated", sort_descending=False)
+        assert [t.id for t in result] == ["2", "1"]
+
+    def test_none_sort_preserves_order(self):
+        tasks = [_make_task("1", "A"), _make_task("2", "B")]
+        result = _apply_task_filters(tasks, sort_field=None)
+        assert [t.id for t in result] == ["1", "2"]
+
+
+class TestApplyTaskFiltersCombined:
+    def test_status_then_sort(self):
+        tasks = [
+            _make_task("1", "A", status="to do", priority="3"),
+            _make_task("2", "B", status="in progress", priority="1"),
+            _make_task("3", "C", status="to do", priority="1"),
+        ]
+        result = _apply_task_filters(tasks, statuses={"to do"}, sort_field="priority", sort_descending=False)
+        assert [t.id for t in result] == ["3", "1"]
+
+    def test_all_filters_combined(self):
+        tasks = [
+            _make_task("1", "Old open", status="to do", status_type="open", date_updated="500"),
+            _make_task("2", "New open", status="to do", status_type="open", date_updated="2000"),
+            _make_task("3", "New closed", status="complete", status_type="closed", date_updated="2000"),
+            _make_task("4", "New progress", status="in progress", status_type="custom", date_updated="2000"),
+        ]
+        result = _apply_task_filters(
+            tasks,
+            statuses={"to do", "in progress"},
+            updated_since_ms=1000,
+            open_only=True,
+        )
+        # Old open (#1) filtered by updated_since. Closed (#3) filtered by open_only.
+        # Only #2 (to do) and #4 (in progress) survive.
+        assert {t.id for t in result} == {"2", "4"}
+
+
+# ---------------------------------------------------------------------------
+# task search CLI integration tests (via mocked client)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchOptionalQuery:
+    @patch("clickup.cli.commands.task.get_client")
+    def test_bare_search_enumerates_all(self, mock_get_client):
+        """Omitting --query returns all tasks (empty string query)."""
+        mock_client = AsyncMock()
+        mock_client.search_tasks.return_value = [Task(id="t1", name="All")]
+        mock_get_client.return_value = _ctx(mock_client)
+
+        result = runner.invoke(app, ["task", "search", "--workspace-id", "W1"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["count"] == 1
+        mock_client.search_tasks.assert_awaited_once_with("W1", "")
+
+    @patch("clickup.cli.commands.task.get_client")
+    def test_search_with_query_passes_through(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.search_tasks.return_value = [Task(id="t1", name="Match")]
+        mock_get_client.return_value = _ctx(mock_client)
+
+        result = runner.invoke(app, ["task", "search", "--query", "hello", "--workspace-id", "W1"])
+        assert result.exit_code == 0
+        mock_client.search_tasks.assert_awaited_once_with("W1", "hello")
+
+
+class TestSearchStatusFilter:
+    @patch("clickup.cli.commands.task.get_client")
+    def test_status_filters_results(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.search_tasks.return_value = [
+            Task(id="t1", name="Open", status={"status": "to do", "type": "open"}),
+            Task(id="t2", name="Done", status={"status": "complete", "type": "closed"}),
+        ]
+        mock_get_client.return_value = _ctx(mock_client)
+
+        result = runner.invoke(
+            app,
+            ["task", "search", "--query", "x", "--workspace-id", "W1", "--status", "to do"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["count"] == 1
+        assert data["data"][0]["id"] == "t1"
+
+    @patch("clickup.cli.commands.task.get_client")
+    def test_multi_status_csv(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.search_tasks.return_value = [
+            Task(id="t1", name="A", status={"status": "to do", "type": "open"}),
+            Task(id="t2", name="B", status={"status": "in progress", "type": "custom"}),
+            Task(id="t3", name="C", status={"status": "complete", "type": "closed"}),
+        ]
+        mock_get_client.return_value = _ctx(mock_client)
+
+        result = runner.invoke(
+            app,
+            ["task", "search", "--query", "x", "--workspace-id", "W1", "--status", "to do,in progress"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["count"] == 2
+        assert {t["id"] for t in data["data"]} == {"t1", "t2"}
+
+
+class TestSearchSort:
+    @patch("clickup.cli.commands.task.get_client")
+    def test_sort_by_priority(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.search_tasks.return_value = [
+            Task(id="t1", name="Low", priority={"id": "4", "priority": "4"}),
+            Task(id="t2", name="Urgent", priority={"id": "1", "priority": "1"}),
+        ]
+        mock_get_client.return_value = _ctx(mock_client)
+
+        result = runner.invoke(
+            app,
+            ["task", "search", "--query", "x", "--workspace-id", "W1", "--sort", "priority"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert [t["id"] for t in data["data"]] == ["t2", "t1"]
+
+    @patch("clickup.cli.commands.task.get_client")
+    def test_sort_desc(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.search_tasks.return_value = [
+            Task(id="t1", name="A", priority={"id": "1", "priority": "1"}),
+            Task(id="t2", name="B", priority={"id": "4", "priority": "4"}),
+        ]
+        mock_get_client.return_value = _ctx(mock_client)
+
+        result = runner.invoke(
+            app,
+            ["task", "search", "--query", "x", "--workspace-id", "W1", "--sort", "priority:desc"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert [t["id"] for t in data["data"]] == ["t2", "t1"]
+
+
+class TestSearchOpenOnly:
+    @patch("clickup.cli.commands.task.get_client")
+    def test_open_only_hides_closed(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.search_tasks.return_value = [
+            Task(id="t1", name="Open", status={"status": "to do", "type": "open"}),
+            Task(id="t2", name="Closed", status={"status": "complete", "type": "closed"}),
+        ]
+        mock_get_client.return_value = _ctx(mock_client)
+
+        result = runner.invoke(
+            app,
+            ["task", "search", "--query", "x", "--workspace-id", "W1", "--open-only"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["count"] == 1
+        assert data["data"][0]["id"] == "t1"
+
+
+class TestSearchUpdatedSince:
+    @patch("clickup.cli.commands.task.get_client")
+    def test_updated_since_filters(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.search_tasks.return_value = [
+            Task(id="t1", name="Old", date_updated="1000"),
+            Task(id="t2", name="New", date_updated="1800000000000"),
+        ]
+        mock_get_client.return_value = _ctx(mock_client)
+
+        result = runner.invoke(
+            app,
+            [
+                "task",
+                "search",
+                "--query",
+                "x",
+                "--workspace-id",
+                "W1",
+                "--updated-since",
+                "2025-01-01",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["count"] == 1
+        assert data["data"][0]["id"] == "t2"
+
+
+class TestSearchLimit:
+    @patch("clickup.cli.commands.task.get_client")
+    def test_limit_caps_results(self, mock_get_client):
+        mock_client = AsyncMock()
+        mock_client.search_tasks.return_value = [Task(id=f"t{i}", name=f"Task {i}") for i in range(10)]
+        mock_get_client.return_value = _ctx(mock_client)
+
+        result = runner.invoke(
+            app,
+            ["task", "search", "--query", "x", "--workspace-id", "W1", "--limit", "3"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["count"] == 3
+
+
+class TestSearchNoWorkspaceErrors:
+    def test_no_workspace_errors(self):
+        result = runner.invoke(app, ["task", "search", "--query", "foo"])
+        assert result.exit_code != 0
+        assert "workspace" in result.stderr.lower()


### PR DESCRIPTION
## Summary
- Extracts the client-side post-filter + sort pipeline into `_apply_task_filters()`, shared by `task list`, `task mine`, and `task search` so the filter matrix can't drift (issue #35 item 1, flagged by 3 of 15 study agents)
- `task search` gains `--status`, `--sort`/`--reverse`, `--updated-since`, `--open-only`, `--limit`; `--query` is now optional — bare `task search` is the workspace-wide enumeration agents kept reaching for
- `task list` behavior unchanged (server-side status/date filters preserved; only open-only + sort run client-side); `task mine` behavior unchanged, now via the shared helper
- Empty-query verified across all three adapters: each returns all tasks

## Test plan
- [x] 24 new tests (14 unit on the shared pipeline, 10 CLI-level on the new search flags)
- [x] Existing list/mine tests pass unmodified (refactor is behavior-preserving)
- [x] `just fc` — 528 passed, coverage 90.64%

Part of #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)