### PR TITLE
Suppress info/success stderr envelopes in JSON mode

### DIFF
--- a/clickup/cli/output.py
+++ b/clickup/cli/output.py
@@ -600,13 +600,28 @@ def render_statuses(statuses: list[dict[str, Any]], *, list_id: str, list_name: 
 
 
 def render_message(msg: str, level: Literal["info", "success", "warn", "error"] = "info") -> None:
-    """Print a styled one-line message. Respects ``--format json`` by emitting
-    ``{"message": ..., "level": ...}`` on stderr (info/success/warn/error all
-    route to stderr in JSON mode so stdout stays a single data envelope).
+    """Print a styled one-line message.
+
+    In **JSON mode**:
+
+    * ``info`` and ``success`` → **no-op** (emit nothing).  These levels
+      are purely informational and the stdout data envelope already carries
+      equivalent context (e.g. ``count``).  Suppressing them prevents
+      JSON-shaped stderr lines from being misread as data contamination by
+      agents that consume merged terminal output.
+    * ``warn`` and ``error`` → stderr envelope
+      ``{"message": ..., "level": ...}`` (unchanged).
+
+    In **table mode** all levels behave as before: info/success go to the
+    Rich console on stdout; warn/error go to stderr via ``typer.echo``.
+
+    Exit codes are never affected by this function.
     """
     if get_format() == "json":
-        # Commentary, warnings, and errors are all stderr-bound in JSON mode
-        # so the data envelope on stdout stays a single parseable JSON value.
+        if level in ("info", "success"):
+            return
+        # Warnings and errors are stderr-bound in JSON mode so the data
+        # envelope on stdout stays a single parseable JSON value.
         typer.echo(json.dumps({"message": msg, "level": level}), err=True)
         return
     if level in ("error", "warn"):

--- a/tests/integration/test_final_coverage.py
+++ b/tests/integration/test_final_coverage.py
@@ -147,7 +147,7 @@ def test_setup_token_validation_then_smoke_test(mock_client_cls):
 
     result = runner.invoke(
         app,
-        ["setup", "run", "--token", "pk", "--list-id", "L1", "--non-interactive"],
+        ["--format", "table", "setup", "run", "--token", "pk", "--list-id", "L1", "--non-interactive"],
     )
     assert result.exit_code == 0
     assert "smoke test" in result.output.lower()

--- a/tests/integration/test_setup_wizard.py
+++ b/tests/integration/test_setup_wizard.py
@@ -69,7 +69,7 @@ def test_setup_with_token_and_single_workspace_auto_selects(mock_client_cls):
     client = _mock_client(teams=[team], spaces=[space], lists=[lst])
     mock_client_cls.return_value = _ctx(client)
 
-    result = runner.invoke(app, ["setup", "run", "--token", "pk_test", "--non-interactive"])
+    result = runner.invoke(app, ["--format", "table", "setup", "run", "--token", "pk_test", "--non-interactive"])
     assert result.exit_code == 0, result.output
     assert "Auto-selected workspace" in result.output
     assert "Auto-selected space" in result.output
@@ -89,6 +89,8 @@ def test_setup_with_all_flags_no_prompts(mock_client_cls):
     result = runner.invoke(
         app,
         [
+            "--format",
+            "table",
             "setup",
             "run",
             "--token",

--- a/tests/unit/test_main_error_envelope.py
+++ b/tests/unit/test_main_error_envelope.py
@@ -155,3 +155,24 @@ def test_main_success_path_exits_zero(
     captured = capsys.readouterr()
     data = json.loads(captured.out)
     assert data["count"] >= 1
+
+
+def test_main_json_mode_suppresses_info_on_stderr(
+    json_provider_env,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end: JSON-mode info messages are suppressed — stderr is clean.
+
+    ``task list`` emits data on stdout; any info-level render_message calls
+    (e.g. count summaries) must NOT leak to stderr in JSON mode.  This pins
+    the contract added in the json-info-suppression change.
+    """
+    monkeypatch.setattr("sys.argv", ["clickup", "task", "list", "--brief"])
+    main()
+    captured = capsys.readouterr()
+    # stdout should have valid JSON data
+    data = json.loads(captured.out)
+    assert data["count"] >= 1
+    # stderr must be completely empty — no info envelopes
+    assert captured.err == ""

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -562,14 +562,23 @@ def test_render_message_error_to_stderr(capsys):
     assert "oops" in captured.err
 
 
-def test_render_message_json_info_to_stderr(capsys):
-    """In JSON mode info messages go to stderr so stdout stays a single data envelope."""
+def test_render_message_json_info_suppressed(capsys):
+    """In JSON mode info messages are suppressed (no stdout, no stderr)."""
     set_format("json")
     render_message("hi", "info")
     captured = capsys.readouterr()
-    data = json.loads(captured.err)
-    assert data == {"message": "hi", "level": "info"}
     assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_render_message_json_success_suppressed(capsys):
+    """In JSON mode success messages are suppressed — mutation commands already
+    emit their data envelope on stdout."""
+    set_format("json")
+    render_message("done!", "success")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
 
 
 def test_render_message_json_warn_to_stderr(capsys):
@@ -578,6 +587,23 @@ def test_render_message_json_warn_to_stderr(capsys):
     captured = capsys.readouterr()
     data = json.loads(captured.err)
     assert data == {"message": "warn-msg", "level": "warn"}
+
+
+def test_render_message_json_error_to_stderr(capsys):
+    set_format("json")
+    render_message("err-msg", "error")
+    captured = capsys.readouterr()
+    data = json.loads(captured.err)
+    assert data == {"message": "err-msg", "level": "error"}
+
+
+def test_render_message_table_info_still_prints(capsys):
+    """Table mode is completely unaffected — info still goes to stdout."""
+    set_format("table")
+    render_message("hello-table", "info")
+    captured = capsys.readouterr()
+    assert "hello-table" in captured.out
+    assert captured.err == ""
 
 
 # ---------- render_error ------------------------------------------------------


### PR DESCRIPTION
## Summary
- In JSON mode, `render_message` now no-ops for `info` and `success`; `warn`/`error` envelopes unchanged; table mode unchanged (issue #35 item 7 — 4 agents across 3 study rounds misread JSON-shaped stderr info as stdout contamination; the perception is the ergonomic fact)
- Safe to suppress success: audited every mutation call site — each already emits its data envelope on stdout in JSON mode (e.g. `task delete` → `{"id", "deleted": true}`) before the success message
- Audited for renderer bypasses emitting JSON-shaped info lines: none found

## Test plan
- [x] Contract tests: JSON info/success → silence, JSON warn/error → stderr envelope, table info → prints
- [x] End-to-end through real `main()` (CliRunner bypasses it — lesson from the round-3 exit-code regression)
- [x] `just fc` — 508 passed, coverage 90.60%

Part of #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)