### PR TITLE
Batch A: modify-if-passed fixes, markup escaping, config bug fixes

### DIFF
--- a/clickup/cli/commands/bulk.py
+++ b/clickup/cli/commands/bulk.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from ...core import ClickUpError, Config, TaskProvider, get_provider, provider_requires_credentials
@@ -322,7 +323,7 @@ def bulk_update(
             )
             raise typer.Exit(1)
 
-        if not any([new_status, new_priority, new_assignee]):
+        if new_status is None and new_priority is None and new_assignee is None:
             render_error("Error: Must specify at least one update (--status, --priority, or --assignee)")
             raise typer.Exit(1)
 
@@ -356,17 +357,17 @@ def bulk_update(
                 table.add_column("New Priority", style="yellow")
 
                 updates: dict[str, Any] = {}
-                if new_status:
+                if new_status is not None:
                     updates["status"] = new_status
-                if new_priority:
+                if new_priority is not None:
                     updates["priority"] = new_priority
-                if new_assignee:
+                if new_assignee is not None:
                     updates["assignees"] = [new_assignee]
 
                 for lid, task in all_tasks[:10]:  # Show first 10
                     current_status = task.status.status if task.status else "Unknown"
                     current_priority = (task.priority.priority or "None") if task.priority else "None"
-                    row = [task.name[:30] + "..." if len(task.name) > 30 else task.name]
+                    row = [escape(task.name[:30] + "..." if len(task.name) > 30 else task.name)]
                     if len(list_ids_to_use) > 1:
                         row.append(lid)
                     row.extend(

--- a/clickup/cli/commands/discover.py
+++ b/clickup/cli/commands/discover.py
@@ -2,6 +2,7 @@
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from ...core import ClickUpError, Config, TaskProvider, get_provider, provider_requires_credentials
@@ -136,7 +137,7 @@ def show_ids(
                         table.add_column("Tasks", style="yellow")
 
                         for lst in lists:
-                            table.add_row(lst.name, lst.id, str(lst.task_count))
+                            table.add_row(escape(lst.name), lst.id, str(lst.task_count))
                         console.print(table)
                     else:
                         console.print("[yellow]No lists found in this folder.[/yellow]")
@@ -152,14 +153,14 @@ def show_ids(
                     try:
                         folders = await client.get_folders(space_id)
                         for folder in folders:
-                            table.add_row("📂 Folder", folder.name, folder.id, f"{folder.task_count} tasks")
+                            table.add_row("📂 Folder", escape(folder.name), folder.id, f"{folder.task_count} tasks")
                     except ClickUpError:
                         pass
 
                     try:
                         lists = await client.get_folderless_lists(space_id)
                         for lst in lists:
-                            table.add_row("📋 List", lst.name, lst.id, f"{lst.task_count} tasks")
+                            table.add_row("📋 List", escape(lst.name), lst.id, f"{lst.task_count} tasks")
                     except ClickUpError:
                         pass
 
@@ -179,7 +180,10 @@ def show_ids(
 
                         for space in spaces:
                             table.add_row(
-                                space.name, space.id, "Yes" if space.private else "No", str(len(space.statuses))
+                                escape(space.name),
+                                space.id,
+                                "Yes" if space.private else "No",
+                                str(len(space.statuses)),
                             )
                         console.print(table)
                     else:
@@ -197,7 +201,10 @@ def show_ids(
 
                         for workspace in workspaces:
                             table.add_row(
-                                workspace.name, workspace.id, workspace.color or "N/A", str(len(workspace.members))
+                                escape(workspace.name),
+                                workspace.id,
+                                workspace.color or "N/A",
+                                str(len(workspace.members)),
                             )
                         console.print(table)
 
@@ -225,7 +232,7 @@ def find_path(list_id: str = typer.Argument(..., help="List ID to find path for"
 
                 # Build path by working backwards
                 path_parts = []
-                path_parts.append(f"📋 [green]{lst.name}[/green] ([dim]{lst.id}[/dim])")
+                path_parts.append(f"📋 [green]{escape(lst.name)}[/green] ([dim]{lst.id}[/dim])")
 
                 # Find which folder/space contains this list
                 workspaces = await client.get_teams()
@@ -245,9 +252,11 @@ def find_path(list_id: str = typer.Argument(..., help="List ID to find path for"
                             try:
                                 folderless_lists = await client.get_folderless_lists(space.id)
                                 if any(lst.id == list_id for lst in folderless_lists):
-                                    path_parts.insert(0, f"📁 [blue]{space.name}[/blue] ([dim]{space.id}[/dim])")
                                     path_parts.insert(
-                                        0, f"🏢 [cyan]{workspace.name}[/cyan] ([dim]{workspace.id}[/dim])"
+                                        0, f"📁 [blue]{escape(space.name)}[/blue] ([dim]{space.id}[/dim])"
+                                    )
+                                    path_parts.insert(
+                                        0, f"🏢 [cyan]{escape(workspace.name)}[/cyan] ([dim]{workspace.id}[/dim])"
                                     )
                                     found_path = True
                                     break
@@ -262,13 +271,14 @@ def find_path(list_id: str = typer.Argument(..., help="List ID to find path for"
                                         lists = await client.get_lists(folder.id)
                                         if any(lst.id == list_id for lst in lists):
                                             path_parts.insert(
-                                                0, f"📂 [yellow]{folder.name}[/yellow] ([dim]{folder.id}[/dim])"
+                                                0, f"📂 [yellow]{escape(folder.name)}[/yellow] ([dim]{folder.id}[/dim])"
                                             )
                                             path_parts.insert(
-                                                0, f"📁 [blue]{space.name}[/blue] ([dim]{space.id}[/dim])"
+                                                0, f"📁 [blue]{escape(space.name)}[/blue] ([dim]{space.id}[/dim])"
                                             )
                                             path_parts.insert(
-                                                0, f"🏢 [cyan]{workspace.name}[/cyan] ([dim]{workspace.id}[/dim])"
+                                                0,
+                                                f"🏢 [cyan]{escape(workspace.name)}[/cyan] ([dim]{workspace.id}[/dim])",
                                             )
                                             found_path = True
                                             break

--- a/clickup/cli/commands/list.py
+++ b/clickup/cli/commands/list.py
@@ -176,13 +176,13 @@ def create_list(
         try:
             list_data: dict[str, Any] = {"name": name}
 
-            if content:
+            if content is not None:
                 list_data["content"] = content
-            if due_date:
+            if due_date is not None:
                 list_data["due_date"] = due_date
-            if priority:
+            if priority is not None:
                 list_data["priority"] = priority
-            if assignee:
+            if assignee is not None:
                 list_data["assignee"] = assignee
 
             async with await get_client() as client:

--- a/clickup/cli/commands/setup.py
+++ b/clickup/cli/commands/setup.py
@@ -8,6 +8,7 @@ required-but-missing value an error rather than a prompt.
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from ...core import ClickUpClient, Config
@@ -241,7 +242,7 @@ def setup_wizard(
                     console.print(f"  Found {len(tasks)} tasks. Here are the first {len(sample)}:")
                     for t in sample:
                         status_str = t.status.status if t.status else "?"
-                        console.print(f"    - {t.name} [{status_str}]")
+                        console.print(f"    - {escape(f'{t.name} [{status_str}]')}")
                 else:
                     console.print("  [dim]No tasks in this list yet.[/dim]")
             except Exception as e:

--- a/clickup/cli/commands/task.py
+++ b/clickup/cli/commands/task.py
@@ -585,13 +585,13 @@ def create_task(
         try:
             task_data: dict[str, Any] = {"name": name}
 
-            if description:
+            if description is not None:
                 task_data["description"] = description
-            if priority:
+            if priority is not None:
                 task_data["priority"] = priority
-            if assignee:
+            if assignee is not None:
                 task_data["assignees"] = [assignee]
-            if due_date:
+            if due_date is not None:
                 task_data["due_date"] = due_date
             if status_to_use:
                 task_data["status"] = status_to_use

--- a/clickup/core/config.py
+++ b/clickup/core/config.py
@@ -181,9 +181,8 @@ class Config:
             self.config_path.parent.mkdir(parents=True, exist_ok=True)
             with open(self.config_path, "w") as f:
                 json.dump(self._config.model_dump(exclude_none=True), f, indent=2)
-        except (OSError, PermissionError):
-            # Handle permission errors gracefully
-            pass
+        except OSError as e:
+            print(f"Warning: failed to save config to {self.config_path}: {e}", file=sys.stderr)
 
     def save(self) -> None:
         """Alias for save_config for test compatibility."""
@@ -215,12 +214,6 @@ class Config:
         Prints a warning to stderr for unrecognised keys but does not error,
         preserving backward compatibility.
         """
-        # Blacklist obviously invalid keys
-        invalid_keys = {"invalid_key", "bad_key", "wrong_key"}
-
-        if key in invalid_keys:
-            raise ValueError(f"Unknown configuration key: {key}")
-
         # Warn (but don't error) on unknown keys for forward compat
         if not is_known_key(key):
             print(
@@ -249,7 +242,6 @@ class Config:
             self.save_config()
             return
 
-        # Handle direct keys - allow if not blacklisted
         setattr(self._config, key, value)
         self.save_config()
 

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -73,13 +73,13 @@ def test_config_set_get():
             assert "60" in result.stdout
 
 
-def test_config_invalid_key():
-    """Test setting invalid configuration key."""
+def test_config_set_unknown_key_warns():
+    """Unknown config keys warn but are stored (forward compat)."""
     with tempfile.TemporaryDirectory() as tmpdir:
         with patch.dict("os.environ", {"HOME": tmpdir}):
-            result = runner.invoke(app, ["config", "set", "invalid_key", "value"])
-            assert result.exit_code == 1
-            assert "Error" in result.output
+            result = runner.invoke(app, ["config", "set", "some_unknown_key", "value"])
+            assert result.exit_code == 0
+            assert "not a recognised config key" in result.output
 
 
 @patch("clickup.cli.commands.task.get_client")

--- a/tests/integration/test_task_commands.py
+++ b/tests/integration/test_task_commands.py
@@ -916,3 +916,52 @@ def test_task_error_handling(mock_get_client):
     result = runner.invoke(app, ["task", "list", "--list-id", "list123"])
 
     assert result.exit_code != 0
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_create_empty_description_is_sent(mock_get_client):
+    """--description '' must reach the provider, not be silently dropped."""
+    mock_client = AsyncMock()
+    task_mock = Mock()
+    task_mock.id = "new_task"
+    task_mock.name = "New Task"
+    mock_client.create_task.return_value = task_mock
+
+    def create_mock_client():
+        ctx_mgr = AsyncMock()
+        ctx_mgr.__aenter__.return_value = mock_client
+        return ctx_mgr
+
+    mock_get_client.side_effect = create_mock_client
+
+    result = runner.invoke(app, ["task", "create", "New Task", "--list-id", "list123", "--description", ""])
+
+    assert result.exit_code == 0
+    kwargs = mock_client.create_task.call_args.kwargs
+    assert kwargs["description"] == ""
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_create_omitted_fields_not_sent(mock_get_client):
+    """Fields not passed on the command line must not appear in the payload."""
+    mock_client = AsyncMock()
+    task_mock = Mock()
+    task_mock.id = "new_task"
+    task_mock.name = "New Task"
+    mock_client.create_task.return_value = task_mock
+
+    def create_mock_client():
+        ctx_mgr = AsyncMock()
+        ctx_mgr.__aenter__.return_value = mock_client
+        return ctx_mgr
+
+    mock_get_client.side_effect = create_mock_client
+
+    result = runner.invoke(app, ["task", "create", "New Task", "--list-id", "list123"])
+
+    assert result.exit_code == 0
+    kwargs = mock_client.create_task.call_args.kwargs
+    assert "description" not in kwargs
+    assert "priority" not in kwargs
+    assert "assignees" not in kwargs
+    assert "due_date" not in kwargs

--- a/tests/unit/test_core_config.py
+++ b/tests/unit/test_core_config.py
@@ -64,12 +64,15 @@ def test_config_headers_no_token(temp_config_dir, monkeypatch):
         config.get_headers()
 
 
-def test_set_invalid_key(temp_config_dir):
-    """Test setting invalid configuration key."""
+def test_set_unknown_key_warns_but_stores(temp_config_dir, capsys):
+    """Unknown keys warn to stderr but are still stored (forward compat)."""
     config = Config(config_path=temp_config_dir / "config.json")
 
-    with pytest.raises(ValueError, match="Unknown configuration key"):
-        config.set("invalid_key", "value")
+    config.set("some_unknown_key", "value")
+
+    captured = capsys.readouterr()
+    assert "not a recognised config key" in captured.err
+    assert config.get("some_unknown_key") == "value"
 
 
 def test_default_values(temp_config_dir):

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -655,3 +655,28 @@ def test_error_payload_omits_empty_fields():
     assert error_payload("x") == {"error": "x"}
     assert error_payload("x", error_type="T") == {"error": "x", "type": "T"}
     assert error_payload("x", hint="h", command="c") == {"error": "x", "hint": "h", "command": "c"}
+
+
+# ---------------------------------------------------------------------------
+# Rich markup escaping of user data (AGENT.md decision 6)
+# ---------------------------------------------------------------------------
+
+
+def test_render_task_table_escapes_brackets(capture_console):
+    """Task names like '[bug] crash' must render verbatim, not as Rich markup."""
+    render_task(_task(name="[bug] crash on save"))
+    out = capture_console.getvalue()
+    assert "[bug] crash on save" in out
+
+
+def test_render_tasks_table_escapes_brackets(capture_console):
+    render_tasks([_task(name="[WIP] feature"), _task(id="task43", name="[red]alert[/red]")])
+    out = capture_console.getvalue()
+    assert "[WIP] feature" in out
+    assert "[red]alert[/red]" in out
+
+
+def test_render_list_table_escapes_brackets(capture_console):
+    render_list(ClickUpList(id="l1", name="[Q3] roadmap"))
+    out = capture_console.getvalue()
+    assert "[Q3] roadmap" in out


### PR DESCRIPTION
## Summary

First batch of a comprehensive refactoring pass (audit-driven). Correctness bugs only — no behavior redesign.

- **Modify-if-passed violations**: `task create`, `list create`, and `bulk bulk-update` used truthy checks (`if description:`), silently dropping explicitly-passed empty/zero values like `--description ""`. Now `is not None` per AGENT.md decision 3.
- **Rich markup escaping**: `discover ids`/`discover path`, `setup run` smoke test, and `bulk bulk-update` preview interpolated user-controlled names into Rich markup — task names like `[bug] foo` were mangled. Added `escape()` at all injection points + renderer regression tests.
- **Config bugs**: `save_config()` silently swallowed write failures (now warns to stderr); removed the leaked `{"invalid_key", "bad_key", "wrong_key"}` test-scaffolding blacklist — unknown keys now uniformly follow the documented warn-but-store path.

## Test plan

- [x] `just fc` green (564 passed, coverage 90.6%)
- [x] New regression tests: empty-description create reaches provider; omitted fields absent from payload; bracket names render verbatim in table mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)