### PR TITLE
Batch D: agent-surface consistency (batch delete, export flag, config alias)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -104,7 +104,7 @@ PR changes `TaskProvider` or the models, it must update the spec too.
 Every user-visible output is rendered via functions in `clickup/cli/output.py`:
 `render_user`, `render_team(s)`, `render_space(s)`, `render_list(s)`, `render_task(s)`, `render_comments`, `render_kv`, `render_message`. They read the global format setting via `get_format()` and emit either a Rich table or structured JSON.
 
-Direct `console.print` of structured data is a regression — route it through a renderer instead. Some legacy commands (`discover hierarchy`, `workspace list`) still bypass this; migrating them is a known follow-up.
+Direct `console.print` of structured data is a regression — route it through a renderer instead. All commands now route through `output.py` renderers.
 
 JSON shape:
 - Collections: `{"data": [...], "count": N}`
@@ -112,7 +112,7 @@ JSON shape:
 
 ### 2. `--format` is a GLOBAL flag, not per-command
 
-Wired on the root Typer callback in `main.py`. **JSON is the default** — agents are first-class consumers, so the unflagged path emits structured data. Pass `clickup --format table <subcommand> ...` for human-readable output. Per-subcommand `--format` would conflict and confuse agents. The `bulk export-tasks` command's pre-existing `--format` (for output FILE format) is the one exception and is unrelated.
+Wired on the root Typer callback in `main.py`. **JSON is the default** — agents are first-class consumers, so the unflagged path emits structured data. Pass `clickup --format table <subcommand> ...` for human-readable output. Per-subcommand `--format` would conflict and confuse agents. Both `task export` and `bulk export-tasks` use `--output-format` for the output FILE format (json/csv), which is unrelated to the global `--format`. `bulk export-tasks` retains `--format` as a deprecated alias for backward compatibility.
 
 ### 3. Modify-if-passed update semantics
 

--- a/clickup/cli/commands/bulk.py
+++ b/clickup/cli/commands/bulk.py
@@ -23,7 +23,7 @@ console = Console()
 def export_tasks(
     list_id: str | None = typer.Option(None, "--list-id", help="List ID to export tasks from"),
     output_file: str = typer.Option("tasks.csv", "--output", "-o", help="Output file path"),
-    format: str = typer.Option("csv", "--format", "-f", help="Output format (csv, json)"),
+    output_format: str = typer.Option("csv", "--output-format", "--format", "-f", help="Output format (csv, json)"),
     include_completed: bool = typer.Option(True, "--include-completed", help="Include completed tasks"),
 ) -> None:
     """Export tasks to CSV or JSON file."""
@@ -39,7 +39,7 @@ def export_tasks(
 
                 tasks = await client.get_tasks(list_id_to_use, **filters)
 
-                if format.lower() == "csv":
+                if output_format.lower() == "csv":
                     # Export to CSV
                     with open(output_file, "w", newline="", encoding="utf-8") as csvfile:
                         fieldnames = [
@@ -77,7 +77,7 @@ def export_tasks(
                                 }
                             )
 
-                elif format.lower() == "json":
+                elif output_format.lower() == "json":
                     # Export to JSON
                     task_data = []
                     for task in tasks:
@@ -95,9 +95,9 @@ def export_tasks(
                         json.dump(task_data, jsonfile, indent=2, ensure_ascii=False)
 
                 else:
-                    render_error(f"Unsupported format: {format}")
+                    render_error(f"Unsupported format: {output_format}")
                     raise typer.Exit(1) from None
-                render_kv({"exported": len(tasks), "output_file": output_file, "format": format.lower()})
+                render_kv({"exported": len(tasks), "output_file": output_file, "format": output_format.lower()})
 
         except ClickUpError as e:
             render_error(f"ClickUp API Error: {e}", error_type=type(e).__name__)

--- a/clickup/cli/commands/task.py
+++ b/clickup/cli/commands/task.py
@@ -8,6 +8,7 @@ import typer
 
 from ...core import ClickUpError, Config
 from ..output import (
+    _print_json,
     get_format,
     render_comment,
     render_comments,
@@ -779,7 +780,8 @@ def task_park(
 
 @app.command("delete")
 def delete_task(
-    task_id: str = typer.Argument(..., help="Task ID"),
+    task_id: str | None = typer.Argument(None, help="Task ID"),
+    task_ids: str | None = typer.Option(None, "--task-ids", help="Comma-separated task IDs to delete"),
     force: bool = typer.Option(
         False,
         "--force",
@@ -789,20 +791,53 @@ def delete_task(
         help="Required to confirm deletion. No interactive prompt.",
     ),
 ) -> None:
-    """Delete a task."""
+    """Delete one or more tasks.
+
+    Positional form: clickup task delete TASK_ID --force
+    Batch form: clickup task delete --task-ids ID1,ID2 --force
+    """
 
     async def _delete_task() -> None:
+        if task_id is not None and task_ids is not None:
+            usage_error("Error: pass TASK_ID either as a positional argument OR via --task-ids, not both.")
+        target_ids = [task_id] if task_id is not None else split_csv(task_ids)
+        if not target_ids:
+            usage_error("Error: Task ID or --task-ids is required.")
+
         if not force:
             render_error("Refusing to delete without --force/--yes (this CLI never prompts).", error_type="UsageError")
             raise typer.Exit(2)
 
-        with handle_clickup_errors():
-            async with await get_client() as client:
-                await client.delete_task(task_id)
-                if get_format() == "json":
-                    render_kv({"id": task_id, "deleted": True})
-                    return
-                render_message(f"Deleted task {task_id}", "success")
+        succeeded: list[dict[str, object]] = []
+        failures: list[tuple[str, Exception]] = []
+        async with await get_client() as client:
+            for tid in target_ids:
+                try:
+                    await client.delete_task(tid)
+                    succeeded.append({"id": tid, "deleted": True})
+                except ClickUpError as e:
+                    failures.append((tid, e))
+                    render_message(f"Failed to delete task {tid}: {e}", "warn")
+
+        if get_format() == "json":
+            if len(target_ids) == 1 and not failures:
+                render_kv({"id": target_ids[0], "deleted": True})
+            else:
+                results = list(succeeded) + [{"id": tid, "deleted": False} for tid, _ in failures]
+                _print_json({"data": results, "count": len(results)})
+        else:
+            if succeeded and not failures:
+                if len(succeeded) == 1:
+                    render_message(f"Deleted task {succeeded[0]['id']}", "success")
+                else:
+                    render_message(f"Deleted {len(succeeded)} tasks.", "success")
+            elif succeeded:
+                render_message(f"Deleted {len(succeeded)}/{len(target_ids)} tasks ({len(failures)} failed).", "warn")
+
+        for tid, exc in failures:
+            render_error(f"ClickUp API Error ({tid}): {exc}", error_type=type(exc).__name__)
+        if failures:
+            raise typer.Exit(1)
 
     run_async(_delete_task())
 
@@ -883,7 +918,7 @@ def search_tasks(
 def export_tasks(
     list_id: str | None = typer.Option(None, "--list-id", "-l", help="List ID to export tasks from"),
     output_file: str = typer.Option("tasks.json", "--output", "-o", help="Output file path"),
-    format: str = typer.Option("json", "--format", "-f", help="Output format (json, csv)"),
+    output_format: str = typer.Option("json", "--output-format", help="Output format (json, csv)"),
     include_completed: bool = typer.Option(True, "--include-completed", help="Include completed tasks"),
 ) -> None:
     """Export tasks from a list to a file."""
@@ -898,7 +933,7 @@ def export_tasks(
                     filters["include_closed"] = False
 
                 tasks = await client.get_tasks(list_id_to_use, **filters)
-                if format.lower() == "json":
+                if output_format.lower() == "json":
                     import json
 
                     task_data = []
@@ -916,7 +951,7 @@ def export_tasks(
                     with open(output_file, "w", encoding="utf-8") as jsonfile:
                         json.dump(task_data, jsonfile, indent=2, ensure_ascii=False)
 
-                elif format.lower() == "csv":
+                elif output_format.lower() == "csv":
                     import csv
 
                     with open(output_file, "w", newline="", encoding="utf-8") as csvfile:
@@ -941,10 +976,10 @@ def export_tasks(
                                 }
                             )
                 else:
-                    render_error(f"Unsupported format: {format}")
+                    render_error(f"Unsupported format: {output_format}")
                     raise typer.Exit(1)
 
-                render_kv({"exported": len(tasks), "output_file": output_file, "format": format.lower()})
+                render_kv({"exported": len(tasks), "output_file": output_file, "format": output_format.lower()})
 
     run_async(_export_tasks())
 

--- a/clickup/core/config.py
+++ b/clickup/core/config.py
@@ -57,10 +57,18 @@ KNOWN_CONFIG_KEYS: set[str] = {
 # Nested prefixes that are always allowed (e.g. "ui.theme", "api.retry")
 KNOWN_NESTED_PREFIXES: set[str] = {"ui", "api"}
 
+# Aliases that normalise to canonical key names. Checked by both ``set`` and
+# ``get`` so there is exactly one stored source of truth.
+KEY_ALIASES: dict[str, str] = {
+    "default_list": "default_list_id",
+}
+
 
 def is_known_key(key: str) -> bool:
-    """Return True if *key* is a recognised configuration key."""
+    """Return True if *key* is a recognised configuration key or alias."""
     if key in KNOWN_CONFIG_KEYS:
+        return True
+    if key in KEY_ALIASES:
         return True
     # Allow any nested key under known prefixes
     if "." in key:
@@ -190,6 +198,9 @@ class Config:
 
     def get(self, key: str, default: Any = None, from_env: bool = False) -> Any:
         """Get configuration value with support for nested keys."""
+        # Resolve aliases before anything else
+        key = KEY_ALIASES.get(key, key)
+
         if from_env and key == "default_team_id":
             env_value = os.getenv("CLICKUP_DEFAULT_TEAM_ID")
             if env_value:
@@ -214,6 +225,9 @@ class Config:
         Prints a warning to stderr for unrecognised keys but does not error,
         preserving backward compatibility.
         """
+        # Resolve aliases before anything else
+        key = KEY_ALIASES.get(key, key)
+
         # Warn (but don't error) on unknown keys for forward compat
         if not is_known_key(key):
             print(

--- a/tests/integration/test_task_commands.py
+++ b/tests/integration/test_task_commands.py
@@ -890,7 +890,9 @@ def test_task_export_json(mock_get_client, sample_tasks):
     mock_get_client.side_effect = create_mock_client
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-        result = runner.invoke(app, ["task", "export", "--list-id", "list123", "--output", f.name, "--format", "json"])
+        result = runner.invoke(
+            app, ["task", "export", "--list-id", "list123", "--output", f.name, "--output-format", "json"]
+        )
 
         assert result.exit_code == 0
         # New behavior: structured result envelope, not a success message.
@@ -965,3 +967,179 @@ def test_task_create_omitted_fields_not_sent(mock_get_client):
     assert "priority" not in kwargs
     assert "assignees" not in kwargs
     assert "due_date" not in kwargs
+
+
+# --- task delete --task-ids batch tests ---
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_delete_task_ids_batch(mock_get_client):
+    """`task delete --task-ids` deletes multiple tasks in one invocation."""
+    mock_client = AsyncMock()
+    mock_client.delete_task.return_value = True
+
+    def create_mock_client():
+        ctx_mgr = AsyncMock()
+        ctx_mgr.__aenter__.return_value = mock_client
+        return ctx_mgr
+
+    mock_get_client.side_effect = create_mock_client
+
+    result = runner.invoke(app, ["task", "delete", "--task-ids", "task1,task2,task3", "--force"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["count"] == 3
+    assert all(item["deleted"] is True for item in data["data"])
+    assert [item["id"] for item in data["data"]] == ["task1", "task2", "task3"]
+    assert mock_client.delete_task.await_count == 3
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_delete_single_positional_still_works(mock_get_client):
+    """Single positional task_id still works for backward compat."""
+    mock_client = AsyncMock()
+    mock_client.delete_task.return_value = True
+
+    def create_mock_client():
+        ctx_mgr = AsyncMock()
+        ctx_mgr.__aenter__.return_value = mock_client
+        return ctx_mgr
+
+    mock_get_client.side_effect = create_mock_client
+
+    result = runner.invoke(app, ["task", "delete", "task999", "--force"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data == {"id": "task999", "deleted": True}
+
+
+def test_task_delete_both_positional_and_task_ids_exits_2():
+    """Passing both positional TASK_ID and --task-ids is a usage error."""
+    result = runner.invoke(app, ["task", "delete", "task1", "--task-ids", "task2", "--force"])
+    assert result.exit_code == 2
+    assert "either as a positional argument OR via --task-ids" in result.stderr
+
+
+def test_task_delete_neither_positional_nor_task_ids_exits_2():
+    """Passing neither positional TASK_ID nor --task-ids is a usage error."""
+    result = runner.invoke(app, ["task", "delete", "--force"])
+    assert result.exit_code == 2
+    assert "Task ID or --task-ids is required" in result.stderr
+
+
+def test_task_delete_batch_without_force_exits_2():
+    """--task-ids without --force is refused (exit 2)."""
+    result = runner.invoke(app, ["task", "delete", "--task-ids", "task1,task2"])
+    assert result.exit_code == 2
+    assert "Refusing to delete" in result.stderr
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_delete_partial_failure_reflects_in_output(mock_get_client):
+    """When some deletions fail, output shows deleted=false and exit code is 1."""
+    from clickup.core import ClickUpError
+
+    mock_client = AsyncMock()
+    mock_client.delete_task.side_effect = [
+        True,
+        ClickUpError("Not found"),
+        True,
+    ]
+
+    def create_mock_client():
+        ctx_mgr = AsyncMock()
+        ctx_mgr.__aenter__.return_value = mock_client
+        return ctx_mgr
+
+    mock_get_client.side_effect = create_mock_client
+
+    result = runner.invoke(app, ["task", "delete", "--task-ids", "task1,task2,task3", "--force"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.stdout)
+    assert data["count"] == 3
+    # task1 succeeded, task2 failed, task3 succeeded
+    assert data["data"][0] == {"id": "task1", "deleted": True}
+    assert data["data"][1] == {"id": "task3", "deleted": True}
+    assert data["data"][2] == {"id": "task2", "deleted": False}
+
+
+# --- task export --output-format tests ---
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_export_output_format_csv(mock_get_client, sample_tasks):
+    """`task export --output-format csv` writes CSV."""
+    mock_client = AsyncMock()
+    mock_client.get_tasks.return_value = sample_tasks
+
+    def create_mock_client():
+        ctx_mgr = AsyncMock()
+        ctx_mgr.__aenter__.return_value = mock_client
+        return ctx_mgr
+
+    mock_get_client.side_effect = create_mock_client
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        result = runner.invoke(
+            app, ["task", "export", "--list-id", "list123", "--output", f.name, "--output-format", "csv"]
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["format"] == "csv"
+
+
+def test_task_export_old_format_flag_rejected():
+    """`task export --format json` is no longer accepted (exit 2)."""
+    result = runner.invoke(app, ["task", "export", "--list-id", "list123", "--format", "json"])
+    assert result.exit_code == 2
+
+
+# --- bulk export-tasks --output-format + --format back-compat ---
+
+
+@patch("clickup.cli.commands.bulk.get_client")
+def test_bulk_export_output_format_flag(mock_get_client):
+    """`bulk export-tasks --output-format csv` works."""
+    mock_client = AsyncMock()
+    mock_client.get_tasks.return_value = []
+
+    def create_mock_client():
+        ctx_mgr = AsyncMock()
+        ctx_mgr.__aenter__.return_value = mock_client
+        return ctx_mgr
+
+    mock_get_client.side_effect = create_mock_client
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        result = runner.invoke(
+            app, ["bulk", "export-tasks", "--list-id", "123", "--output-format", "csv", "--output", f.name]
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["format"] == "csv"
+
+
+@patch("clickup.cli.commands.bulk.get_client")
+def test_bulk_export_format_back_compat(mock_get_client):
+    """`bulk export-tasks --format csv` still works (deprecated alias)."""
+    mock_client = AsyncMock()
+    mock_client.get_tasks.return_value = []
+
+    def create_mock_client():
+        ctx_mgr = AsyncMock()
+        ctx_mgr.__aenter__.return_value = mock_client
+        return ctx_mgr
+
+    mock_get_client.side_effect = create_mock_client
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        result = runner.invoke(app, ["bulk", "export-tasks", "--list-id", "123", "--format", "csv", "--output", f.name])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["format"] == "csv"

--- a/tests/integration/test_task_coverage.py
+++ b/tests/integration/test_task_coverage.py
@@ -233,7 +233,7 @@ def test_task_export_json(mock_get_client):
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
         result = runner.invoke(
             app,
-            ["task", "export", "--list-id", "L1", "--output", f.name, "--format", "json"],
+            ["task", "export", "--list-id", "L1", "--output", f.name, "--output-format", "json"],
         )
     assert result.exit_code == 0
     data = json.loads(Path(f.name).read_text())
@@ -249,7 +249,7 @@ def test_task_export_csv(mock_get_client):
     with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
         result = runner.invoke(
             app,
-            ["task", "export", "--list-id", "L1", "--output", f.name, "--format", "csv"],
+            ["task", "export", "--list-id", "L1", "--output", f.name, "--output-format", "csv"],
         )
     assert result.exit_code == 0
     content = Path(f.name).read_text()
@@ -266,7 +266,7 @@ def test_task_export_unsupported_format_errors(mock_get_client):
     with tempfile.NamedTemporaryFile(suffix=".xml") as f:
         result = runner.invoke(
             app,
-            ["task", "export", "--list-id", "L1", "--output", f.name, "--format", "xml"],
+            ["task", "export", "--list-id", "L1", "--output", f.name, "--output-format", "xml"],
         )
     assert result.exit_code != 0
     assert "Unsupported" in result.stderr

--- a/tests/unit/test_core_config.py
+++ b/tests/unit/test_core_config.py
@@ -106,6 +106,39 @@ def test_config_file_precedence(temp_config_dir, monkeypatch):
     assert config.get_api_token() == "file_token"
 
 
+class TestKeyAliases:
+    """Tests for KEY_ALIASES (e.g. default_list -> default_list_id)."""
+
+    def test_set_via_alias_stores_canonical_key(self, temp_config_dir):
+        """``config.set('default_list', ...)`` stores as ``default_list_id``."""
+        config = Config(config_path=temp_config_dir / "config.json")
+        config.set("default_list", "12345")
+        assert config.get("default_list_id") == "12345"
+
+    def test_get_via_alias_returns_canonical_value(self, temp_config_dir):
+        """``config.get('default_list')`` reads from ``default_list_id``."""
+        config = Config(config_path=temp_config_dir / "config.json")
+        config.set("default_list_id", "67890")
+        assert config.get("default_list") == "67890"
+
+    def test_alias_round_trip(self, temp_config_dir):
+        """Set via alias, reload, get via alias."""
+        path = temp_config_dir / "config.json"
+        config = Config(config_path=path)
+        config.set("default_list", "round_trip_id")
+
+        config2 = Config(config_path=path)
+        assert config2.get("default_list") == "round_trip_id"
+        assert config2.get("default_list_id") == "round_trip_id"
+
+    def test_alias_does_not_trigger_unknown_key_warning(self, temp_config_dir, capsys):
+        """Setting via alias should NOT produce the unknown-key warning."""
+        config = Config(config_path=temp_config_dir / "config.json")
+        config.set("default_list", "no_warning")
+        captured = capsys.readouterr()
+        assert "not a recognised config key" not in captured.err
+
+
 class TestClickupConfigPathEnvVar:
     """Tests for CLICKUP_CONFIG_PATH environment variable support."""
 


### PR DESCRIPTION
## Summary

Fourth batch of the audit-driven refactor (follows #41–#43). Finishes the remaining items from issues #22 and #24.

- **`task delete --task-ids id1,id2,...`** — batch deletion mirroring `task update`/`task status`: positional XOR flag (exit 2 on misuse), `--force` still required, JSON `{"data": [...], "count": N}` with per-ID `deleted` status, exit 1 on partial failure
- **`task export --output-format`** — the local `--format` flag shadowed the global output format (AGENT.md decision 2 sanctions only `bulk export-tasks`); renamed, and the Python param no longer shadows the `format` builtin. `bulk export-tasks` gains `--output-format` with `--format`/`-f` kept as deprecated aliases
- **`default_list` config alias** — `config set/get default_list` normalizes to `default_list_id` (single source of truth, no unknown-key warning); closes the last item of #24
- AGENT.md refreshed: output-contract section no longer lists already-migrated commands; decision 2 documents the export flag rename

## Test plan

- [x] `just fc` green (602 passed, coverage 90.3%)
- [x] New tests: batch delete (success/partial failure/usage errors/force gate), export flag rename on both commands, config alias round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)