### PR TITLE
Declare click dependency, bump to 0.4.0

### DIFF
--- a/clickup/__init__.py
+++ b/clickup/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit - A powerful CLI for ClickUp task management."""
 
-__version__ = "0.2.0"
+__version__ = "0.4.0"
 
 # Import main modules
 from . import cli, core

--- a/clickup/cli/__init__.py
+++ b/clickup/cli/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit CLI - Command-line interface for ClickUp."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 from .main import app, main
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clickup-toolkit"
-version = "0.3.0"
+version = "0.4.0"
 description = "A powerful CLI for ClickUp task management"
 authors = [
     { name = "Evan Oman", email = "evan@example.com" }
@@ -18,6 +18,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "click>=8.0.0",
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-11T03:18:27.38997935Z"
+exclude-newer = "2026-06-05T04:48:23.193894997Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -129,9 +129,10 @@ wheels = [
 
 [[package]]
 name = "clickup-toolkit"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "httpx" },
     { name = "plankapy", version = "2.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "plankapy", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
@@ -153,6 +154,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "plankapy", specifier = ">=2.2.2" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary

- `clickup/cli/main.py` imports `click` directly (error-envelope handling) but `click` was undeclared — only present transitively via typer. Surfaced as `ModuleNotFoundError` from a stale uvx wheel cache while setting up the agent eval
- Version 0.3.0 → 0.4.0 across pyproject and both `__version__` constants (one was stale at 0.2.0); also busts the uvx name+version wheel cache so agents get the refactored CLI

## Test plan

- [x] `just fc` green (619 passed)
- [x] `uvx --python 3.13 --from . clickup version` works in a fresh environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)