### PR TITLE
Eval follow-ups: --format hint, alias error UX, README agent coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The fastest way for an AI agent to use this CLI -- no clone, no install:
 uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup --help
 ```
 
-Three-command happy path:
+Four-command happy path:
 
 ```bash
 # 1. Interactive setup -- stores your API token and picks defaults
@@ -22,7 +22,10 @@ uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup setup
 # 2. Verify everything works
 uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup status
 
-# 3. List tasks in your default list
+# 3. Discover list IDs in your workspace
+uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup discover hierarchy
+
+# 4. List tasks in your default list
 uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup task list
 ```
 
@@ -72,7 +75,17 @@ clickup status   # should print "Auth Status: Valid"
 
 Get a personal token from **ClickUp → Settings → Apps → API Token**.
 
-### 3. Configure aliases for your spaces and a default status
+### 3. Discover your list IDs
+
+Before configuring aliases, find the numeric list IDs for the lists you want agents to target:
+
+```bash
+clickup discover hierarchy          # prints workspace > space > folder > list tree with IDs
+```
+
+Or use `clickup setup run --non-interactive --token <token> --team-id <id> --space-id <id> --list-id <id>` for fully scriptable setup.
+
+### 4. Configure aliases for your spaces and a default status
 
 Agents shouldn't have to run discovery commands every time they create a task. Map your real list IDs to short aliases so the agent can route by name:
 
@@ -85,9 +98,9 @@ clickup config set-default-list personal <list-id>
 clickup config set default_status on-deck   # tasks land in your "ready" column by default
 ```
 
-Find the IDs with `clickup discover hierarchy --depth 5`.
+Find the IDs with `clickup discover hierarchy --depth 5`. The `--list-id` flag accepts both numeric IDs and configured aliases (e.g. `--list-id omegapoint`).
 
-### 4. Add a shell alias (optional)
+### 5. Add a shell alias (optional)
 
 Short one-liner so the agent (and you) can type `cup` instead of the full binary name:
 
@@ -98,7 +111,7 @@ alias cup='clickup'
 # alias cup='uv run --project /path/to/clickup-tools clickup'
 ```
 
-### 5. Teach your agent how to use it
+### 6. Teach your agent how to use it
 
 Drop this snippet into your agent's global instructions file. For Claude Code that's `~/.claude/CLAUDE.md`; for Cursor it's `.cursorrules` (project-level) or the user-level rules file; for Codex CLI it's `~/.codex/AGENTS.md` (project-level `AGENTS.md` works too); for Aider it's `~/.aider.conf.yml`'s `read` setting.
 
@@ -228,6 +241,16 @@ clickup task get task123
 
 # Update a task
 clickup task update task123 --name "Updated name"
+
+# Search tasks across your workspace
+clickup task search --query "keyword"
+
+# List tasks assigned to you
+clickup task mine
+
+# View and add comments
+clickup task comments list <task-id>
+clickup task comments add <task-id> "Comment text"
 ```
 
 ### 4. Configuration
@@ -274,6 +297,10 @@ uv run ty check
 - `clickup task get` - Get task details
 - `clickup task update` - Update existing tasks
 - `clickup task delete` - Delete tasks
+- `clickup task mine` - List tasks assigned to you across all configured lists
+- `clickup task search` - Search tasks by keyword across a workspace
+- `clickup task comments list` - List comments on a task
+- `clickup task comments add` - Add a comment to a task
 
 ### Workspace navigation
 - `clickup workspace list` - List workspaces/teams

--- a/clickup/cli/main.py
+++ b/clickup/cli/main.py
@@ -266,6 +266,20 @@ def _wants_json_mode(argv: list[str]) -> bool:
     return True
 
 
+def _format_hint(exc: click.ClickException) -> str | None:
+    """Return a targeted hint when --format is misplaced after a subcommand.
+
+    ``--format`` is a global flag on the root Typer callback. When agents
+    place it after the subcommand (e.g. ``clickup task search --format table``),
+    Click raises ``NoSuchOption`` because the subcommand doesn't declare it.
+    This helper detects that specific case and returns an actionable hint.
+    """
+    option_name = getattr(exc, "option_name", None)
+    if option_name and option_name.lstrip("-") == "format":
+        return "Global flag --format goes before the subcommand: clickup --format <table|json> <command> ..."
+    return None
+
+
 def _emit_click_error_envelope(exc: click.ClickException) -> None:
     """Render a click.ClickException as the canonical JSON error envelope.
 
@@ -277,7 +291,8 @@ def _emit_click_error_envelope(exc: click.ClickException) -> None:
     """
     ctx = getattr(exc, "ctx", None)
     command = ctx.command_path if ctx is not None and ctx.command_path else None
-    payload = error_payload(exc.format_message(), error_type=exc.__class__.__name__, command=command)
+    hint = _format_hint(exc)
+    payload = error_payload(exc.format_message(), error_type=exc.__class__.__name__, command=command, hint=hint)
     typer.echo(json.dumps(payload), err=True)
 
 
@@ -303,6 +318,9 @@ def main() -> None:
             _emit_click_error_envelope(e)
         else:
             e.show()
+            hint = _format_hint(e)
+            if hint:
+                typer.echo(f"Hint: {hint}", err=True)
         sys.exit(e.exit_code or 2)
     except click.exceptions.ClickException as e:
         # UsageError + its subclasses (NoSuchOption, BadParameter, etc.) are

--- a/clickup/cli/shared.py
+++ b/clickup/cli/shared.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 import typer
 from rich.console import Console
 
-from ..core import ClickUpError, Config, get_provider, provider_requires_credentials
+from ..core import ClickUpError, Config, get_provider, provider_name, provider_requires_credentials
 from .output import render_error
 
 if TYPE_CHECKING:
@@ -39,8 +39,33 @@ def usage_error(msg: str, hint: str | None = None) -> NoReturn:
 
 
 def resolve_list_id(list_id: str | None) -> str | None:
-    """Resolve a list ID, expanding configured aliases."""
-    return Config().resolve_list_id(list_id)
+    """Resolve a list ID, expanding configured aliases.
+
+    For the ``clickup`` provider, non-numeric values that are not configured
+    aliases are rejected early with a helpful usage error (exit 2) instead of
+    being forwarded to the API where they produce an opaque failure.
+
+    Other providers (``json``, ``planka``) use non-numeric list IDs
+    legitimately, so the strictness is skipped for them.  The check is also
+    skipped when the clickup provider has no credentials configured, since
+    the request will fail later at the ``get_client`` stage anyway (and this
+    avoids false positives in test environments where ``get_client`` is mocked).
+    """
+    config = Config()
+    resolved = config.resolve_list_id(list_id)
+    # If the caller passed a value AND it came back unchanged AND it isn't
+    # numeric, that means it didn't match any alias.  For the ClickUp SaaS
+    # provider, numeric IDs are required — surface the mismatch now.
+    # The credentials gate prevents false positives when get_client is mocked.
+    is_clickup = provider_name(config) == "clickup" and config.has_credentials()
+    if list_id is not None and resolved == list_id and not list_id.isdigit() and is_clickup:
+        aliases: dict[str, str] = config.get("default_lists") or {}
+        alias_names = ", ".join(sorted(aliases.keys())) if aliases else "(none)"
+        usage_error(
+            f"Unknown list or alias '{list_id}'. Configured aliases: {alias_names}.",
+            hint="Run 'clickup config get default_lists' to see aliases, or 'clickup setup run' to configure them.",
+        )
+    return resolved
 
 
 def split_csv(value: str | None) -> list[str]:
@@ -71,14 +96,14 @@ def resolve_list_ids(list_id: str | None, *, all_lists: bool = False) -> list[st
 
     raw_values = split_csv(list_id)
     if not raw_values:
-        resolved = config.resolve_list_id(None)
+        resolved = resolve_list_id(None)
         return [resolved] if resolved else []
-    return [resolved for raw in raw_values if (resolved := config.resolve_list_id(raw))]
+    return [resolved for raw in raw_values if (resolved := resolve_list_id(raw))]
 
 
 def require_list_id(list_id: str | None) -> str:
     """Resolve a list ID and exit 2 if none is available."""
-    resolved = Config().resolve_list_id(list_id)
+    resolved = resolve_list_id(list_id)
     if resolved:
         return resolved
     usage_error(

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -15,7 +15,7 @@ import click
 import pytest
 from typer.testing import CliRunner
 
-from clickup.cli.main import _emit_click_error_envelope, _wants_json_mode, app, main
+from clickup.cli.main import _emit_click_error_envelope, _format_hint, _wants_json_mode, app, main
 from clickup.core.models import List as ClickUpList
 from clickup.core.models import Space, Team
 
@@ -361,3 +361,69 @@ def test_main_json_mode_suppresses_info_on_stderr(
     data = json.loads(captured.out)
     assert data["count"] >= 1
     assert captured.err == ""
+
+
+# =============================================================================
+# --format hint when placed after subcommand (item 1)
+# =============================================================================
+
+
+class TestFormatHint:
+    def test_format_hint_detects_format_option(self) -> None:
+        exc = click.exceptions.NoSuchOption("--format")
+        assert _format_hint(exc) is not None
+        assert "--format" in _format_hint(exc)
+        assert "before the subcommand" in _format_hint(exc)
+
+    def test_format_hint_ignores_other_options(self) -> None:
+        exc = click.exceptions.NoSuchOption("--foo")
+        assert _format_hint(exc) is None
+
+    def test_format_hint_ignores_non_nosuchoption(self) -> None:
+        exc = click.exceptions.UsageError("some error")
+        assert _format_hint(exc) is None
+
+
+def test_main_format_after_subcommand_json_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``clickup task search --format json`` (default mode) emits JSON envelope with hint on stderr."""
+    monkeypatch.setattr("sys.argv", ["clickup", "task", "search", "--query", "x", "--format", "json"])
+    with pytest.raises(SystemExit) as exit_info:
+        main()
+    assert exit_info.value.code == 2
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert payload["type"] == "NoSuchOption"
+    assert "hint" in payload
+    assert "before the subcommand" in payload["hint"]
+
+
+def test_main_format_after_subcommand_table_mode_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``clickup --format table task search --format table`` shows hint on stderr."""
+    argv = ["clickup", "--format", "table", "task", "search", "--query", "x", "--format", "table"]
+    monkeypatch.setattr("sys.argv", argv)
+    with pytest.raises(SystemExit) as exit_info:
+        main()
+    assert exit_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "Hint:" in captured.err
+    assert "before the subcommand" in captured.err
+
+
+def test_main_unknown_option_no_format_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unknown option that isn't --format gets no hint."""
+    monkeypatch.setattr("sys.argv", ["clickup", "version", "--bogus"])
+    with pytest.raises(SystemExit) as exit_info:
+        main()
+    assert exit_info.value.code == 2
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert "hint" not in payload

--- a/tests/unit/test_shared.py
+++ b/tests/unit/test_shared.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import pytest
 import typer
 
-from clickup.cli.shared import gather_bounded, get_client, handle_clickup_errors, require_list_id
+from clickup.cli.shared import gather_bounded, get_client, handle_clickup_errors, require_list_id, resolve_list_id
 from clickup.core.exceptions import ClickUpError
 
 
@@ -19,13 +20,102 @@ class TestRequireListId:
         Config().set("default_list_id", "L42")
         assert require_list_id(None) == "L42"
 
-    def test_explicit_id_passes_through(self):
-        assert require_list_id("explicit123") == "explicit123"
+    def test_explicit_numeric_id_passes_through(self):
+        assert require_list_id("12345") == "12345"
 
     def test_missing_id_exits_2(self):
         with pytest.raises(typer.Exit) as exc:
             require_list_id(None)
         assert exc.value.exit_code == 2
+
+
+class TestResolveListIdValidation:
+    """Tests for unknown-alias detection in resolve_list_id (item 2)."""
+
+    def test_unknown_alias_clickup_provider_exits_2(self, monkeypatch, tmp_path):
+        """Non-numeric, non-alias value with clickup provider should exit 2."""
+        monkeypatch.setenv("CLICKUP_CONFIG_PATH", str(tmp_path / "config.json"))
+        monkeypatch.setenv("CLICKUP_API_KEY", "pk_test_token")
+        monkeypatch.delenv("CLICKUP_PROVIDER", raising=False)
+        from clickup.core import Config
+
+        config = Config()
+        config.set("provider", "clickup")
+        config.set("default_lists", {"inbox": "123", "work": "456"})
+
+        with pytest.raises(typer.Exit) as exc:
+            resolve_list_id("bogusalias")
+        assert exc.value.exit_code == 2
+
+    def test_known_alias_resolves(self, monkeypatch, tmp_path):
+        """A configured alias should resolve to its numeric ID."""
+        monkeypatch.setenv("CLICKUP_CONFIG_PATH", str(tmp_path / "config.json"))
+        monkeypatch.setenv("CLICKUP_API_KEY", "pk_test_token")
+        monkeypatch.delenv("CLICKUP_PROVIDER", raising=False)
+        from clickup.core import Config
+
+        config = Config()
+        config.set("provider", "clickup")
+        config.set("default_lists", {"inbox": "123"})
+
+        assert resolve_list_id("inbox") == "123"
+
+    def test_numeric_id_passes_through(self, monkeypatch, tmp_path):
+        """A numeric ID should pass through without error."""
+        monkeypatch.setenv("CLICKUP_CONFIG_PATH", str(tmp_path / "config.json"))
+        monkeypatch.delenv("CLICKUP_PROVIDER", raising=False)
+        from clickup.core import Config
+
+        Config().set("provider", "clickup")
+        assert resolve_list_id("999") == "999"
+
+    def test_json_provider_passes_nonnumeric(self, monkeypatch, tmp_path):
+        """json provider should pass non-numeric IDs through untouched."""
+        monkeypatch.setenv("CLICKUP_CONFIG_PATH", str(tmp_path / "config.json"))
+        monkeypatch.setenv("CLICKUP_PROVIDER", "json")
+
+        result = resolve_list_id("list_inbox")
+        assert result == "list_inbox"
+
+    def test_unknown_alias_error_lists_configured_aliases(self, monkeypatch, tmp_path, capsys):
+        """The error message should include the configured alias names."""
+        monkeypatch.setenv("CLICKUP_CONFIG_PATH", str(tmp_path / "config.json"))
+        monkeypatch.setenv("CLICKUP_API_KEY", "pk_test_token")
+        monkeypatch.delenv("CLICKUP_PROVIDER", raising=False)
+        from clickup.cli.output import set_format
+        from clickup.core import Config
+
+        set_format("json")
+        config = Config()
+        config.set("provider", "clickup")
+        config.set("default_lists", {"alpha": "1", "beta": "2"})
+
+        with pytest.raises(typer.Exit):
+            resolve_list_id("gamma")
+
+        captured = capsys.readouterr()
+        payload = json.loads(captured.err)
+        assert "alpha" in payload["error"]
+        assert "beta" in payload["error"]
+        assert "gamma" in payload["error"]
+
+    def test_unknown_alias_no_aliases_configured(self, monkeypatch, tmp_path, capsys):
+        """When no aliases are configured, error should say '(none)'."""
+        monkeypatch.setenv("CLICKUP_CONFIG_PATH", str(tmp_path / "config.json"))
+        monkeypatch.setenv("CLICKUP_API_KEY", "pk_test_token")
+        monkeypatch.delenv("CLICKUP_PROVIDER", raising=False)
+        from clickup.cli.output import set_format
+        from clickup.core import Config
+
+        set_format("json")
+        Config().set("provider", "clickup")
+
+        with pytest.raises(typer.Exit):
+            resolve_list_id("bogus")
+
+        captured = capsys.readouterr()
+        payload = json.loads(captured.err)
+        assert "(none)" in payload["error"]
 
 
 class TestHandleClickupErrors:


### PR DESCRIPTION
## Summary

Implements items 1–3 of #49 (from the 2026-06-11 agent eval; items 4–6 remain tracked there).

- **Misplaced `--format`**: `clickup task search ... --format table` now emits `hint: "Global flag --format goes before the subcommand..."` in the JSON error envelope and as a stderr hint in table mode (exit 2). Other unknown options keep the generic message
- **Unknown alias**: non-numeric `--list-id` values that aren't configured aliases fail fast with `Unknown list or alias '<v>'. Configured aliases: ...` instead of an opaque ClickUp "List ID invalid" round-trip — gated to the clickup provider so json/planka non-numeric IDs still pass through
- **README**: `task mine`/`search`/`comments` documented; agent quickstart gains a list-ID discovery step and notes alias support on `--list-id`

## Test plan

- [x] `just fc` green (631 passed, coverage 90.7%)
- [x] Smoke-tested both error paths against the real CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)