### PR TITLE
cli-agent-eval suite v2: 18 tasks, dispatcher-graded rubric

### DIFF
--- a/.claude/skills/cli-agent-eval/SKILL.md
+++ b/.claude/skills/cli-agent-eval/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: cli-agent-eval
-description: Run a fanned-out swarm eval of the ClickUp CLI from an agent's perspective. Dispatches 12 parallel sub-agents, each given a real-world task that exercises a specific behavior. Use when the user asks to evaluate, benchmark, or assess agent-usability of the CLI; or after non-trivial CLI changes to confirm they didn't regress agent ergonomics. Compares results against the baseline captured before the multi-agent refactor.
+description: Run a fanned-out swarm eval of the ClickUp CLI from an agent's perspective. Dispatches 18 parallel sub-agents, each given a real-world task that exercises a specific behavior. Use when the user asks to evaluate, benchmark, or assess agent-usability of the CLI; or after non-trivial CLI changes to confirm they didn't regress agent ergonomics. Compares results against the most recent baseline in evals/.
 ---
 
 # ClickUp CLI Agent-Usability Eval
 
-This skill is a "poor man's eval" — a fixed set of agent-perspective tasks that were originally hand-run as a research swarm, codified for reuse. Re-run it after CLI changes to see whether agent ergonomics improved or regressed.
+A fixed set of agent-perspective tasks, codified for reuse. Re-run after CLI changes to see whether agent ergonomics improved or regressed. The suite measures the CLI, not the sub-agents: every task is something a real coding agent plausibly does for a user, phrased without hints about which commands or flags exist.
+
+**Integrity rule:** when a task fails or shows friction, the fix belongs in the CLI, its docs, or its error messages — never in softening the task prompt, the success criteria, or the grading. Task prompts may only be edited to remove genuine ambiguity, and any such edit must be noted in the run report.
 
 ## How to invoke
 
@@ -20,22 +22,23 @@ When the user asks for an eval / benchmark / agent-usability check, or right aft
    mkdir -p "$(dirname "$CLICKUP_CONFIG_PATH")"
    ```
    This uses the `CLICKUP_CONFIG_PATH` env var (honoured by `Config()`) so the eval's setup wizard, `config set-token`, and any other config writes go to a disposable path instead of `~/.config/clickup-toolkit/config.json`. **Pass this env var to every sub-agent prompt** (see base prompt template below).
-3. Confirm uvx works for this project:
-   `uvx --python 3.13 --from /home/evan/dev/clickup-tools clickup --help` (Python 3.13 is needed because uvx defaults to 3.14 which has a pydantic-core build issue).
+3. **Pre-warm the uvx wheel cache** so 18 parallel agents don't race the build, and so a stale cached wheel can't shadow current source (uvx caches by name+version — see AGENT.md "Local dev caveat"):
+   `uvx --python 3.13 --refresh-package clickup-toolkit --from /home/evan/dev/clickup-tools clickup version`
+   Confirm the reported version matches `pyproject.toml`. If it doesn't, the cache is stale — investigate before dispatching.
 4. Confirm the user's workspace state. Real values for the eval:
    - User: Evan Oman, ID `150240437`, email `evan058@gmail.com`
    - Workspace: `90131945555` ("Evan Oman's Workspace") — singleton
    - Space: `90138201902` ("Team Space")
-   - Lists: Omega Point `901315992466` (most active), Personal `901316076590` (use for write tests), Gen Work Overhead `901316076575`, Historical Echoes `901315992464`
+   - Lists: Omega Point `901315992466`, Personal `901316076590` (**use for all write tests**), Gen Work Overhead `901316076575`, Historical Echoes `901315992464`
 
-## Dispatch the swarm (12 sub-agents in parallel)
+## Dispatch the swarm (18 sub-agents in parallel)
 
-Use the Agent tool, `subagent_type: general-purpose`, `model: opus`, single message with 12 tool calls. Each gets the **base prompt** below with the task-specific bit substituted. Run all in **background** if you want to interleave with other work; otherwise foreground.
+Use the Agent tool, `subagent_type: general-purpose`, `model: opus`, single message with 18 tool calls. Each gets the **base prompt** below with `{TASK}` and `{CLICKUP_CONFIG_PATH}` substituted.
 
 ### Base prompt template
 
 ```
-You are evaluating whether the ClickUp CLI is easy for a brand-new AI agent to use.
+You are evaluating whether the ClickUp CLI is easy for a brand-new AI agent to use. You have never seen this CLI before. Behave like a competent coding agent doing a real job for a user — not like a QA engineer hunting for bugs.
 
 SETUP
 - Project root: /home/evan/dev/clickup-tools
@@ -43,90 +46,97 @@ SETUP
 - Invoke the CLI as a real user would: `uvx --python 3.13 --from /home/evan/dev/clickup-tools clickup ...` (Python 3.13 required — pydantic-core build fails on 3.14).
 - Both `clickup` and `cup` are valid binary names after install.
 - IMPORTANT: Before running any CLI command, export the isolated config path so your writes don't pollute the user's real config:
-  `export CLICKUP_CONFIG_PATH="{CLICKUP_CONFIG_PATH}"` (the dispatcher will substitute the actual path).
+  `export CLICKUP_CONFIG_PATH="{CLICKUP_CONFIG_PATH}"`
 
 HARD CONSTRAINTS
-- Do NOT read the CLI's source code. No Read on clickup/cli/* or clickup/core/*. No grep through those dirs.
+- Do NOT read the CLI's source code. No Read on clickup/cli/* or clickup/core/*. No grep through those dirs. No reading AGENT.md or CLAUDE.md.
 - Your only docs are `--help` output, the README at /home/evan/dev/clickup-tools/README.md, and trial-and-error.
-- Time budget ~5 minutes. If you hit a wall, stop and report.
+- If you create anything, you must also clean it up (delete it / restore original state) before finishing, and say so in your report.
+- Time budget ~5 minutes. If you hit a wall, stop and report honestly — a truthful FAIL is more valuable than a flattering PARTIAL.
 
 YOUR TASK
 {TASK}
 
-REPORT (under 300 words)
+REPORT (under 350 words)
 1. Did you succeed? Y / N / Partial. One-line outcome.
-2. Verbatim sequence of commands run, in order, with one-line outcome each.
-3. Top 3 friction points — be specific (what command, what expected, what got).
+2. Verbatim sequence of CLI commands run, in order, with one-line outcome each. Include failed attempts — they are data, not embarrassment. Mark `--help` calls as (help).
+3. Top friction points (up to 3) — be specific: what you ran, what you expected, what you got.
 4. One concrete suggestion to make this easier for the next agent.
+
+Last lines of your report MUST be a fenced JSON block:
+```json
+{"verdict":"pass|partial|fail", "command_count": <int>, "help_count": <int>, "elapsed_seconds": <int>, "cleanup_done": true|false, "top_friction": "<one sentence>"}
+```
+command_count = CLI invocations that did real work (exclude --help calls; count failed attempts). help_count = --help invocations. elapsed_seconds = rough wall-clock estimate. cleanup_done = whether you deleted/restored everything you created (true if you created nothing).
 ```
 
-### The 12 tasks
+### The 18 tasks
 
 | # | Task description (substitute into `{TASK}`) | Probes |
 |---|---|---|
-| 1 | "Find out who is currently authenticated. Just need their name and email." | identity, status/whoami discovery |
+| 1 | "Find out who is currently authenticated. Just need their name and email." | identity discovery |
 | 2 | "List all the ClickUp teams (workspaces) the user has access to. Report each team's ID and name." | basic read |
 | 3 | "Build a tree of the user's workspace: every space, folder, and list under it." | hierarchy navigation |
-| 4 | "List tasks currently assigned to the authenticated user." | cross-list filtering, `task mine` discoverability |
-| 5 | "Pick any list with tasks and show the 5 most-recently-updated tasks." | sort/order-by discoverability |
-| 6 | "Create a new task titled `agent-test-eval-6 hello world` in any list. Report the task ID and URL. Then DELETE it." | create + delete + 204 handling + bracket safety (note: don't use brackets in the name — that was a bug we fixed but verify) |
-| 7 | "Create `agent-test-eval-7 update-flow` with description `'original'`. Update ONLY its priority to 2. Re-fetch and verify name and description are unchanged. Then delete the task." | modify-if-passed semantics |
-| 8 | "Search the workspace for tasks containing the word 'test'. Report match count and a few examples." | search auto-workspace, semantics |
-| 9 | "Pick any task. Get its full details and list its comments. Note every field that comes back." | task get expansion, comments command |
-| 10 | "Export tasks from any non-empty list to JSON at /tmp/clickup-export-eval-10.json. Then `head -c 500` to confirm." | bulk export |
-| 11 | "Find which list is the user's most active (most tasks / most recent activity). Explain how you decided." | list ranking heuristics |
-| 12 | "Run the no-flag flow: end with `clickup task list` working without any flags. If a default isn't set, set one." | onboarding wizard, default resolution |
+| 4 | "List tasks currently assigned to the authenticated user." | `task mine` discoverability |
+| 5 | "Pick any list with tasks and show the 5 most-recently-updated tasks." | sort discoverability |
+| 6 | "Create a new task titled `agent-test-eval-6 hello world` in the list with ID 901316076590. Report the task ID and URL. Then DELETE it." | create + delete |
+| 7 | "Create a task named `agent-test-eval-7 update-flow` with description `original` in list 901316076590. Update ONLY its priority to 2. Re-fetch and verify name and description are unchanged. Then delete the task." | modify-if-passed |
+| 8 | "Search the workspace for tasks containing the word 'test'. Report the match count and three example titles." | search |
+| 9 | "Pick any existing task. Get its full details and list its comments. Report which fields came back." | task get expansion, comments read |
+| 10 | "Export tasks from any non-empty list to JSON at /tmp/clickup-export-eval-10.json. Then `head -c 500` the file to confirm." | export |
+| 11 | "Find which list is the user's most active (most tasks and most recent activity). Explain how you decided." | list-level stats |
+| 12 | "Starting from zero configuration, end with `clickup task list` working without any flags. If a default isn't set, set one using only non-interactive commands." | onboarding, default resolution |
+| 13 | "Pick any task in list 901316076590. Find out which statuses are valid for that list, move the task to a different valid status, verify the change, then move it back to its original status." | status discovery + transition |
+| 14 | "Create three tasks named `agent-test-eval-14-a`, `agent-test-eval-14-b`, `agent-test-eval-14-c` in list 901316076590. Then, in as few commands as possible, mark all three complete, verify, and delete all three." | batch ops over explicit IDs |
+| 15 | "Report all open (not closed/done) tasks in list 901316076575 that were updated in the last 30 days, sorted most-recently-updated first. Give the count and the titles." | date filters, open-only, sort |
+| 16 | "Create a task named `agent-test-eval-16 comment-flow` in list 901316076590, add the comment `status: looking into it`, read the comments back to verify, then delete the task." | comment write + read round-trip |
+| 17 | "Try to fetch a task with ID `doesnotexist123`. Then create a task named `agent-test-eval-17 err-probe` in list 901316076590 and try to delete it WITHOUT any confirmation/force flags; note what happens; then delete it properly. For each error you encountered: report exactly what the CLI said (message, where it printed, exit code) and whether that output alone told you how to proceed without consulting --help." | error quality: envelopes, exit codes, actionability |
+| 18 | "Using only CLI commands, configure a list alias named `inbox` that points to list 901316076590, then list that list's tasks via the alias. Finally remove the alias you added." | alias configuration + use |
 
-## Scoring rubric
+## Grading — the dispatcher assigns final verdicts
 
-For each task report, classify the outcome:
+Sub-agent self-verdicts are input, not the result. After all reports return, **you** (the dispatcher) grade each task from its command transcript against the criteria below. Where your grade differs from the self-verdict, note why.
 
-- **PASS** — succeeded with ≤4 commands AND no friction worth reporting
-- **PARTIAL** — succeeded but with notable friction (>4 commands, or unclear errors, or workarounds)
-- **FAIL** — couldn't complete
+**Verdicts:**
+- **PASS** — goal fully achieved; ≤6 working CLI invocations (excluding `--help`); no manual workaround for something the CLI should do (e.g., piping JSON to python to filter/sort when a flag exists or should exist); no misleading error encountered; cleanup done.
+- **PARTIAL** — goal achieved but with a workaround, >6 working invocations, a misleading/opaque error along the way, or incomplete cleanup.
+- **FAIL** — goal not achieved within budget.
 
-Then compare to the **baseline** below.
+**Per-task success criteria:**
 
-## Baseline (pre-refactor swarm, recorded for comparison)
-
-Captured before the 6-agent refactor (commits `9966d6c` and earlier). 15 friction items found across the original 15-agent run:
-
-| Probe | Baseline issue | Expected post-refactor verdict |
-|---|---|---|
-| identity (#1) | `status` omitted email; `whoami` didn't exist | resolved (whoami added; status shows email) |
-| hierarchy (#3) | spinner bled into stdout; no JSON output | partial — spinner still bleeds in some commands; `--format json` works at top level |
-| my tasks (#4) | no `task mine`; required 6+ commands | resolved (`task mine` added) |
-| sort (#5) | no `--sort` / `--order-by`; Updated column missing | resolved |
-| create (#6) | brackets `[...]` silently stripped from names | resolved (markup escape) |
-| update (#7) | modify-if-passed worked; `if X:` truthy bug allowed silent drops on empty values | resolved (CLI uses `is not None`) |
-| search (#8) | required `--workspace-id` even with one workspace | partial — auto-detect added but `task search` may still require it |
-| task get (#9) | only 10 of ~25 API fields shown; comments unavailable | resolved (D expanded fields; comments commands added) |
-| bulk export (#10) | `--format` was freeform TEXT not Choice | resolved |
-| most-active (#11) | no `list rank` or activity sort; manual scoring required | NOT addressed — still manual |
-| default list (#12) | required 7-step onboarding; no wizard | resolved (`setup` wizard) |
-| name aliases | `default_lists` field accepted writes but never read | resolved (C wired resolver) |
-| HTTP delete | 204 No Content parsed as error | resolved (B) |
-| workspace members | endpoint 404 | resolved (B) |
-| timestamps | epoch-ms in all output | resolved (ISO in JSON, human in tables) |
-| help discoverability | flat command list, no grouping | resolved (rich panels) |
+| # | Must be true for PASS |
+|---|---|
+| 1 | Correct name + email reported |
+| 2 | Workspace ID + name reported |
+| 3 | All spaces and all 4+ lists enumerated with IDs |
+| 4 | Assigned-task query executed successfully (an empty result is still a pass — workspace state varies) |
+| 5 | 5 tasks in correct updated-desc order |
+| 6 | ID + URL reported; task verifiably deleted |
+| 7 | Re-fetch shows name and description unchanged, priority 2; task deleted |
+| 8 | Count + 3 example titles from a workspace-wide search (not a single-list grep) |
+| 9 | Full field inventory + a comments read (empty list OK) |
+| 10 | File exists, valid JSON, >0 tasks |
+| 11 | A defensible answer naming one list, justified by both task count and recency, without hand-rolling JSON post-processing |
+| 12 | Final bare `clickup task list` exits 0 with task data; no interactive prompts used |
+| 13 | Valid statuses enumerated via the CLI (not guessed); both transitions verified; original status restored |
+| 14 | All three closed AND deleted via batched commands (one command per operation type, not per task) |
+| 15 | Filtering and sorting done by CLI flags, not manual post-processing; count + titles reported |
+| 16 | Comment text read back verbatim; task deleted |
+| 17 | Both errors structured (stderr, correct exit codes: 1 runtime / 2 usage), and agent judged them actionable without --help |
+| 18 | Alias works for task listing; alias removed afterwards |
 
 ## Synthesis report + JSON storage
 
-When you dispatch the swarm, **add this clause to each sub-agent's prompt** so the report is parseable:
+After grading, write a markdown summary AND save structured JSON to `evals/<short-sha>.json` (`<short-sha>` = `git rev-parse --short HEAD`). If that file already exists for the same sha (re-run), suffix `-r2`, `-r3`, ....
 
-> "Last lines of your report MUST be a fenced JSON block of the form:
-> ```json
-> {\"verdict\":\"pass|partial|fail\", \"command_count\": <int>, \"elapsed_seconds\": <int>, \"top_friction\": \"<one sentence>\"}
-> ```
-> Use the start of your response and the end as your elapsed_seconds estimate (round to whole seconds). command_count is the count of CLI invocations you actually ran (not --help calls)."
-
-After all 12 return, write a markdown summary AND save a structured JSON to `evals/<short-sha>.json` (where `<short-sha>` = `git rev-parse --short HEAD` at eval time). JSON shape:
+JSON shape:
 
 ```json
 {
   "commit": "<short-sha>",
   "commit_full": "<full-sha>",
   "timestamp": "<ISO 8601>",
+  "suite_version": 2,
   "summary": {
     "pass": N, "partial": N, "fail": N,
     "total_command_count": N,
@@ -135,47 +145,55 @@ After all 12 return, write a markdown summary AND save a structured JSON to `eva
   "tasks": [
     {
       "id": 1, "name": "identity",
-      "verdict": "pass", "command_count": 7, "elapsed_seconds": 64,
-      "top_friction": "whoami at config not top-level"
-    },
-    ...
+      "verdict": "pass", "self_verdict": "pass",
+      "command_count": 1, "elapsed_seconds": 30,
+      "top_friction": "<one sentence>"
+    }
   ]
 }
 ```
 
-Markdown report sections (in addition to JSON):
+`suite_version: 2` marks the 18-task suite (v1 = the original 12 tasks; totals are not directly comparable across versions — compare per-task and pass-rate instead).
+
+Markdown report sections:
 
 ```
-# CLI Agent-Usability Eval — <date> @ <short-sha>
+# CLI Agent-Usability Eval — <date> @ <short-sha> (suite v2)
 
 ## Summary
-- Tasks run: 12; Pass N · Partial N · Fail N
-- Total commands across all agents: N (delta vs last eval: ±N)
-- Total elapsed across all agents: N seconds (delta vs last eval: ±N)
+- Tasks run: 18; Pass N · Partial N · Fail N
+- Pass rate vs previous run: ±
+- Total commands / elapsed (with per-suite-version caveat)
 
 ## Per-task results
-| # | Task | Verdict | Cmds | Elapsed | Top friction |
-|---|------|---------|------|---------|--------------|
-...
+| # | Task | Verdict | Self | Cmds | Elapsed | Top friction |
 
-## Verdict on each baseline issue (comparison table)
-...
+## Grade overrides (dispatcher vs self-verdict, with reasons)
 
 ## New friction discovered
-...
 
-## Recommended next moves
-- ranked list of 3-5 items
+## Recommended next moves (ranked, ≤5)
 ```
 
-If a previous eval JSON exists in `evals/`, compare summary metrics and call out direction (improved / regressed / mixed).
+If previous eval JSONs exist in `evals/`, compare per-task verdicts for tasks 1–12 and call out direction (improved / regressed / mixed).
 
 ## Cleanup
 
-After the eval, ensure:
-- All test tasks created (anything with `agent-test-eval-*` prefix) are deleted from list `901316076590` (Personal). Use `cup task delete <id> --force`.
-- Remove the disposable eval config directory: `rm -rf "$(dirname "$CLICKUP_CONFIG_PATH")"`. Because the eval used `CLICKUP_CONFIG_PATH`, the user's real `~/.config/clickup-toolkit/config.json` was never touched.
+After the eval:
+- Verify no `agent-test-eval-*` tasks remain in list `901316076590` (Personal): `cup --format json task list --list-id 901316076590` and check; delete leftovers with `cup task delete --task-ids ... --force`.
+- Verify no stray `inbox` alias or other config leaked into the REAL user config (`~/.config/clickup-toolkit/config.json`) — it shouldn't have, thanks to `CLICKUP_CONFIG_PATH`.
+- Remove the disposable eval config dir: `rm -rf "$(dirname "$CLICKUP_CONFIG_PATH")"`.
+- Remove `/tmp/clickup-export-eval-10.json`.
+
+## Result history
+
+| Run | Suite | Commit | Pass/Partial/Fail | Notes |
+|---|---|---|---|---|
+| 2026-05 (baseline) | v1 (12) | `b8bb6b8` | 10/2/0 | pre-refactor friction batch |
+| 2026-06-11 | v1 (12) | `a22824e` | 11/1/0 | post batches A–G; cmds 84→41 |
+
+Append a row after every run.
 
 ## Why this exists
 
-This skill is a regression eval. The original 15-agent swarm surfaced 16 friction items, most of which were addressed in a 6-agent worktree refactor. Re-running this is the cheapest way to confirm fixes stuck and catch new regressions. Each run costs ~12 Opus agent invocations + their tool calls — not free, so don't run it casually.
+This is a regression eval. The original swarm surfaced 16 friction items; subsequent refactors addressed them, and this suite is the cheapest way to confirm fixes stuck and catch new regressions. Each run costs ~18 Opus agent invocations + tool calls — not free, so don't run it casually.


### PR DESCRIPTION
## Summary

- Expands the agent-usability eval from 12 to 18 tasks: status-transition workflow, batch ops over explicit IDs, date-filter triage, comment round-trip, error-quality probe, and alias configuration
- Grading hardened: per-task success criteria, dispatcher assigns final verdicts from command transcripts (agent self-verdicts are input only), PASS requires ≤6 working invocations and no manual workarounds
- Integrity rule documented: friction fixes go in the CLI/docs/errors, never in softening task prompts or grading
- Adds cleanup verification, uvx cache pre-warm step, and a result-history table (v1 runs: b8bb6b8 10/2/0, a22824e 11/1/0)

## Test plan

- [x] Eval-only change; no production code. First v2 run will follow once the product gaps (issue #49 items 4–5) land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)