### PR TITLE
Add list stats and setup run --auto (issue #49 items 4-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ uv run ty check
 - `clickup workspace spaces` - List spaces in a workspace
 - `clickup workspace folders` - List folders in a space
 - `clickup workspace members` - List team members
-- `clickup list` - Manage lists
+- `clickup list` - Manage lists (`clickup list stats` for per-list task/open counts)
 - `clickup discover` - Navigate workspace hierarchy and find IDs
 
 ### Other

--- a/clickup/cli/commands/list.py
+++ b/clickup/cli/commands/list.py
@@ -4,8 +4,9 @@ from typing import Any
 
 import typer
 
-from ..output import render_error, render_list, render_lists, render_message
-from ..shared import get_client, handle_clickup_errors, require_list_id
+from ..output import format_timestamp, render_error, render_list, render_list_stats, render_lists, render_message
+from ..shared import gather_bounded, get_client, handle_clickup_errors, require_list_id, resolve_workspace_id
+from ..task_filters import filter_open_only
 from ..utils import run_async
 
 app = typer.Typer(help="List management")
@@ -161,3 +162,125 @@ def create_list(
                 render_list(list_item)
 
     run_async(_create_list())
+
+
+@app.command("stats")
+def list_stats(
+    workspace_id: str | None = typer.Option(
+        None, "--workspace-id", "-w", help="Workspace ID (auto-detected if only one)."
+    ),
+    space_id: str | None = typer.Option(None, "--space-id", "-s", help="Limit to a single space."),
+    sort: str = typer.Option(
+        "updated", "--sort", help="Sort order: 'tasks' (highest count first) or 'updated' (most recent first)."
+    ),
+) -> None:
+    """Show per-list statistics: task count, open count, and last updated.
+
+    Enumerates every list in the workspace (folders + folderless) and
+    fetches tasks to compute stats. Use --space-id to limit scope.
+    """
+
+    async def _stats() -> None:
+        with handle_clickup_errors():
+            async with await get_client() as client:
+                # Collect all lists across spaces
+                if space_id:
+                    space_ids = [space_id]
+                else:
+                    ws_id = await resolve_workspace_id(client, workspace_id)
+                    spaces = await client.get_spaces(ws_id)
+                    space_ids = [s.id for s in spaces]
+
+                all_lists: list[tuple[str, Any]] = []
+                for sid in space_ids:
+                    # Resolve space name
+                    sp_name = sid
+                    try:
+                        sp = await client.get_space(sid)
+                        sp_name = sp.name
+                    except Exception:
+                        pass
+
+                    # Folderless lists
+                    try:
+                        folderless = await client.get_folderless_lists(sid)
+                        for lst in folderless:
+                            all_lists.append((sp_name, lst))
+                    except Exception:
+                        pass
+
+                    # Folder lists
+                    try:
+                        folders = await client.get_folders(sid)
+                        for folder in folders:
+                            try:
+                                folder_lists = await client.get_lists(folder.id)
+                                for lst in folder_lists:
+                                    all_lists.append((sp_name, lst))
+                            except Exception:
+                                pass
+                    except Exception:
+                        pass
+
+                if not all_lists:
+                    render_list_stats([])
+                    return
+
+                # Fetch tasks for each list (bounded concurrency)
+                async def _fetch_tasks(list_id: str) -> list[Any]:
+                    return await client.get_tasks(list_id, include_closed=True)
+
+                task_results = await gather_bounded(
+                    [_fetch_tasks(lst.id) for _, lst in all_lists],
+                    limit=5,
+                )
+
+                rows: list[dict[str, Any]] = []
+                for (sp_name, lst), tasks_or_exc in zip(all_lists, task_results, strict=True):
+                    if isinstance(tasks_or_exc, Exception):
+                        tasks = []
+                    else:
+                        tasks = tasks_or_exc
+
+                    task_count = len(tasks) if tasks else (lst.task_count or 0)
+                    open_count = len(filter_open_only(tasks)) if tasks else 0
+
+                    # Find most recent date_updated
+                    last_updated: str | None = None
+                    if tasks:
+                        max_ts: int | None = None
+                        for t in tasks:
+                            if t.date_updated:
+                                try:
+                                    ts = int(t.date_updated)
+                                    if max_ts is None or ts > max_ts:
+                                        max_ts = ts
+                                except (TypeError, ValueError):
+                                    pass
+                        if max_ts is not None:
+                            last_updated = format_timestamp(str(max_ts), for_json=True)
+
+                    rows.append(
+                        {
+                            "id": lst.id,
+                            "name": lst.name,
+                            "space": sp_name,
+                            "task_count": task_count,
+                            "open_count": open_count,
+                            "last_updated": last_updated,
+                        }
+                    )
+
+                # Sort
+                if sort == "tasks":
+                    rows.sort(key=lambda r: r["task_count"], reverse=True)
+                else:
+                    # updated: most recent first; None sorts last
+                    rows.sort(
+                        key=lambda r: r["last_updated"] or "",
+                        reverse=True,
+                    )
+
+                render_list_stats(rows)
+
+    run_async(_stats())

--- a/clickup/cli/commands/setup.py
+++ b/clickup/cli/commands/setup.py
@@ -13,7 +13,7 @@ from rich.table import Table
 
 from ...core import ClickUpClient, Config
 from ...core.models import List as ClickUpList
-from ..output import render_error, render_message
+from ..output import render_error, render_kv, render_message
 from ..utils import run_async
 
 app = typer.Typer(help="Setup and onboarding")
@@ -53,6 +53,144 @@ def _suggest_most_active(lists: list[ClickUpList]) -> ClickUpList | None:
     return max(lists, key=lambda lst: (lst.task_count or 0, lst.name))
 
 
+def _run_auto_setup(
+    *,
+    token: str | None,
+    team_id: str | None,
+    space_id: str | None,
+    list_id: str | None,
+) -> None:
+    """Fully automatic, non-interactive setup path (``--auto``).
+
+    Never prompts. Picks singletons automatically, resolves ambiguity
+    via the most-tasks heuristic for lists, and exits 2 when a choice
+    cannot be made without explicit flags.
+    """
+
+    async def _auto() -> None:
+        config = Config()
+
+        # ── Token ─────────────────────────────────────────────────────
+        if token:
+            config.set_api_token(token)
+        if not config.has_credentials():
+            render_error(
+                "No API token configured.",
+                hint=(
+                    "Set CLICKUP_API_KEY in your environment (or .env), pass --token, "
+                    "or run 'clickup setup run' interactively."
+                ),
+            )
+            raise typer.Exit(2)
+
+        async with ClickUpClient(config) as client:
+            is_valid, message, user = await client.validate_auth()
+            if not is_valid or user is None:
+                render_error(f"Token validation failed: {message}")
+                raise typer.Exit(2)
+
+            # ── Workspace ─────────────────────────────────────────────
+            teams = await client.get_teams()
+            if not teams:
+                render_error("No workspaces found for this account.")
+                raise typer.Exit(1)
+
+            if team_id is not None:
+                team = next((t for t in teams if t.id == team_id), None)
+                if team is None:
+                    render_error(f"Team/workspace ID {team_id!r} not found in this account.")
+                    raise typer.Exit(2)
+            elif len(teams) == 1:
+                team = teams[0]
+            else:
+                lines = ", ".join(f"{t.name} ({t.id})" for t in teams)
+                render_error(
+                    f"Multiple workspaces found: {lines}.",
+                    hint="Pass --team-id to select one.",
+                )
+                raise typer.Exit(2)
+
+            config.set("default_team_id", team.id)
+
+            # ── Space ─────────────────────────────────────────────────
+            spaces = await client.get_spaces(team.id)
+            if not spaces:
+                render_error("No spaces found in this workspace.")
+                raise typer.Exit(1)
+
+            if space_id is not None:
+                space = next((s for s in spaces if s.id == space_id), None)
+                if space is None:
+                    render_error(f"Space ID {space_id!r} not found in workspace {team.name}.")
+                    raise typer.Exit(2)
+            elif len(spaces) == 1:
+                space = spaces[0]
+            else:
+                lines = ", ".join(f"{s.name} ({s.id})" for s in spaces)
+                render_error(
+                    f"Multiple spaces found: {lines}.",
+                    hint="Pass --space-id to select one.",
+                )
+                raise typer.Exit(2)
+
+            config.set("default_space_id", space.id)
+
+            # ── List ──────────────────────────────────────────────────
+            all_lists: list[ClickUpList] = await client.get_folderless_lists(space.id)
+            folders = await client.get_folders(space.id)
+            for folder in folders:
+                folder_lists = await client.get_lists(folder.id)
+                all_lists.extend(folder_lists)
+
+            if list_id is not None:
+                chosen_list = next((lst for lst in all_lists if lst.id == list_id), None)
+                if chosen_list is None:
+                    render_error(f"List ID {list_id!r} not found in space {space.name}.")
+                    raise typer.Exit(2)
+            elif not all_lists:
+                render_message("No lists found in this space. Skipping list selection.", "warn")
+                chosen_list = None
+            elif len(all_lists) == 1:
+                chosen_list = all_lists[0]
+            else:
+                # Pick the list with the most tasks; tie-break by first occurrence
+                chosen_list = max(all_lists, key=lambda lst: lst.task_count or 0)
+                tc = chosen_list.task_count or 0
+                render_message(
+                    f"Auto-selected list '{chosen_list.name}' ({tc} tasks). Override with --list-id.",
+                    "warn",
+                )
+
+            if chosen_list is not None:
+                config.set("default_list_id", chosen_list.id)
+
+            # ── Smoke test (lightweight — just validate the list) ─────
+            if chosen_list is not None:
+                try:
+                    await client.get_list(chosen_list.id)
+                except Exception:
+                    pass  # Non-fatal; the config is already saved
+
+            # ── Output ────────────────────────────────────────────────
+            result: dict[str, object] = {
+                "default_team_id": team.id,
+                "default_team_name": team.name,
+                "default_space_id": space.id,
+                "default_space_name": space.name,
+            }
+            if chosen_list is not None:
+                result["default_list_id"] = chosen_list.id
+                result["default_list_name"] = chosen_list.name
+
+            render_kv(result, title="Auto-setup complete")
+
+    try:
+        run_async(_auto())
+    except _NeedsInput as e:
+        render_error(str(e))
+        raise typer.Exit(2) from e
+
+
 @app.command("run")
 def setup_wizard(
     token: str | None = typer.Option(None, "--token", help="ClickUp API token (skips token prompt)."),
@@ -66,13 +204,29 @@ def setup_wizard(
         "--non-interactive",
         help="Fail instead of prompting when a value is missing. Use with --token/--team-id/etc.",
     ),
+    auto: bool = typer.Option(
+        False,
+        "--auto",
+        help=(
+            "Fully automatic setup — never prompts. Uses token from env/.env/--token; "
+            "auto-selects workspace/space if only one exists, picks the list with the "
+            "most tasks when multiple are available. Explicit --team-id/--space-id/--list-id "
+            "flags override auto-selection at that level."
+        ),
+    ),
 ) -> None:
     """Setup wizard — configure defaults for the ClickUp CLI.
 
     Interactive by default. To run non-interactively (agent flow), pass
     --token / --team-id / --space-id / --list-id and (optionally)
     --non-interactive to error on any missing value rather than prompt.
+
+    Use --auto for fully automatic setup: never prompts, auto-selects
+    the best option at each level, and outputs the chosen IDs.
     """
+    if auto:
+        _run_auto_setup(token=token, team_id=team_id, space_id=space_id, list_id=list_id)
+        return
 
     async def _setup() -> None:
         config = Config()

--- a/clickup/cli/main.py
+++ b/clickup/cli/main.py
@@ -66,7 +66,7 @@ console = Console()
 
 @app.command(rich_help_panel="Get started")
 def status() -> None:
-    """Show ClickUp connection status and current configuration."""
+    """Show authenticated user, connection status, and current configuration."""
 
     async def _status() -> None:
         config_manager = Config()

--- a/clickup/cli/output.py
+++ b/clickup/cli/output.py
@@ -742,3 +742,35 @@ def render_error(
         typer.echo(msg, err=True)
         if hint:
             typer.echo(hint, err=True)
+
+
+def render_list_stats(rows: list[dict[str, Any]]) -> None:
+    """Render per-list statistics (task count, open count, last updated).
+
+    Each row is a dict with keys: ``id``, ``name``, ``space``, ``task_count``,
+    ``open_count``, ``last_updated`` (ISO 8601 string or ``None``).
+    """
+    if get_format() == "json":
+        _print_json({"data": rows, "count": len(rows)})
+        return
+
+    table = Table(title="List Stats", show_header=True)
+    table.add_column("Name", style="bold")
+    table.add_column("ID", style="cyan")
+    table.add_column("Tasks", style="green", justify="right")
+    table.add_column("Open", style="blue", justify="right")
+    table.add_column("Last updated", style="yellow")
+
+    for row in rows:
+        last_updated = row.get("last_updated") or "—"
+        # In table mode, truncate ISO timestamps to date-only for readability
+        if last_updated and last_updated != "—" and "T" in last_updated:
+            last_updated = last_updated[:10]
+        table.add_row(
+            escape(str(row.get("name", ""))),
+            str(row.get("id", "")),
+            str(row.get("task_count", 0)),
+            str(row.get("open_count", 0)),
+            last_updated,
+        )
+    _console.print(table)

--- a/clickup/cli/shared.py
+++ b/clickup/cli/shared.py
@@ -108,7 +108,10 @@ def require_list_id(list_id: str | None) -> str:
         return resolved
     usage_error(
         "Error: No list ID provided and no default list configured.",
-        hint="Use --list-id or set a default with 'clickup config set default_list_id <id>'",
+        hint=(
+            "Use --list-id or set a default with 'clickup config set default_list_id <id>', "
+            "or find IDs with 'clickup discover hierarchy'"
+        ),
     )
 
 

--- a/tests/integration/test_list_stats.py
+++ b/tests/integration/test_list_stats.py
@@ -1,0 +1,334 @@
+"""Tests for `clickup list stats` — per-list statistics command."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+from typer.testing import CliRunner
+
+from clickup.cli.main import app
+from clickup.core.models import Folder, Space, SpaceRef, StatusInfo, Task, Team
+from clickup.core.models import List as ClickUpList
+
+from .conftest import make_mock_ctx
+
+runner = CliRunner()
+
+
+def _space(*, id: str = "S1", name: str = "Engineering") -> Space:
+    return Space(id=id, name=name, private=False, statuses=[], multiple_assignees=False)
+
+
+def _team(*, id: str = "T1", name: str = "Acme") -> Team:
+    return Team(id=id, name=name, color="#000", members=[])
+
+
+def _list(*, id: str, name: str, task_count: int = 0) -> ClickUpList:
+    return ClickUpList(id=id, name=name, task_count=task_count)
+
+
+def _folder(*, id: str, name: str, space_id: str = "S1") -> Folder:
+    return Folder(
+        id=id,
+        name=name,
+        orderindex=0,
+        override_statuses=False,
+        hidden=False,
+        space=SpaceRef(id=space_id),
+        task_count="0",
+    )
+
+
+def _task(
+    *,
+    id: str,
+    name: str,
+    date_updated: str | None = None,
+    status_type: str = "open",
+    status_name: str = "open",
+) -> Task:
+    return Task(
+        id=id,
+        name=name,
+        date_updated=date_updated,
+        status=StatusInfo(status=status_name, type=status_type),
+    )
+
+
+def _build_client(
+    *,
+    teams: list[Team] | None = None,
+    spaces: list[Space] | None = None,
+    folders: list[Folder] | None = None,
+    folderless_lists: list[ClickUpList] | None = None,
+    folder_lists: dict[str, list[ClickUpList]] | None = None,
+    tasks_by_list: dict[str, list[Task]] | None = None,
+) -> AsyncMock:
+    """Build a mock client for list stats tests."""
+    client = AsyncMock()
+    client.get_teams.return_value = teams or [_team()]
+    client.get_spaces.return_value = spaces or [_space()]
+    client.get_space.return_value = (spaces or [_space()])[0]
+    client.get_folders.return_value = folders or []
+    client.get_folderless_lists.return_value = folderless_lists or []
+
+    _folder_lists = folder_lists or {}
+
+    async def _get_lists(folder_id: str) -> list[ClickUpList]:
+        return _folder_lists.get(folder_id, [])
+
+    client.get_lists.side_effect = _get_lists
+
+    _tasks = tasks_by_list or {}
+
+    async def _get_tasks(list_id: str, **kwargs) -> list[Task]:
+        return _tasks.get(list_id, [])
+
+    client.get_tasks.side_effect = _get_tasks
+    return client
+
+
+# ---------------------------------------------------------------------------
+# JSON shape and basic behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestListStatsJson:
+    def test_multiple_lists_across_folder_and_folderless(self):
+        """Stats cover both folderless and folder lists."""
+        client = _build_client(
+            folderless_lists=[_list(id="L1", name="Inbox", task_count=3)],
+            folders=[_folder(id="F1", name="Sprint")],
+            folder_lists={"F1": [_list(id="L2", name="Sprint Board", task_count=5)]},
+            tasks_by_list={
+                "L1": [
+                    _task(id="t1", name="Task A", date_updated="1700000000000", status_type="open"),
+                    _task(id="t2", name="Task B", date_updated="1700100000000", status_type="closed"),
+                    _task(id="t3", name="Task C", date_updated="1700200000000", status_type="open"),
+                ],
+                "L2": [
+                    _task(id="t4", name="Task D", date_updated="1700300000000", status_type="open"),
+                    _task(id="t5", name="Task E", date_updated="1700400000000", status_type="open"),
+                ],
+            },
+        )
+        from unittest.mock import patch
+
+        with patch("clickup.cli.commands.list.get_client", return_value=make_mock_ctx(client)):
+            result = runner.invoke(app, ["--format", "json", "list", "stats", "--workspace-id", "T1"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["count"] == 2
+        ids = {row["id"] for row in payload["data"]}
+        assert ids == {"L1", "L2"}
+
+        # Verify counts
+        l1 = next(r for r in payload["data"] if r["id"] == "L1")
+        assert l1["task_count"] == 3
+        assert l1["open_count"] == 2  # t2 is closed
+        assert l1["last_updated"] is not None
+        assert l1["space"] == "Engineering"
+
+        l2 = next(r for r in payload["data"] if r["id"] == "L2")
+        assert l2["task_count"] == 2
+        assert l2["open_count"] == 2
+
+    def test_sort_by_tasks(self):
+        """--sort tasks orders by task_count descending."""
+        client = _build_client(
+            folderless_lists=[
+                _list(id="L1", name="Few", task_count=2),
+                _list(id="L2", name="Many", task_count=10),
+            ],
+            tasks_by_list={
+                "L1": [
+                    _task(id="t1", name="A", date_updated="1700000000000"),
+                    _task(id="t2", name="B", date_updated="1700100000000"),
+                ],
+                "L2": [_task(id=f"t{i}", name=f"T{i}", date_updated=f"{1700000000000 + i * 1000}") for i in range(10)],
+            },
+        )
+        from unittest.mock import patch
+
+        with patch("clickup.cli.commands.list.get_client", return_value=make_mock_ctx(client)):
+            result = runner.invoke(
+                app, ["--format", "json", "list", "stats", "--workspace-id", "T1", "--sort", "tasks"]
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["data"][0]["id"] == "L2"
+        assert payload["data"][1]["id"] == "L1"
+
+    def test_sort_by_updated(self):
+        """--sort updated (default) orders by most recently updated first."""
+        client = _build_client(
+            folderless_lists=[
+                _list(id="L1", name="Old"),
+                _list(id="L2", name="New"),
+            ],
+            tasks_by_list={
+                "L1": [_task(id="t1", name="A", date_updated="1600000000000")],
+                "L2": [_task(id="t2", name="B", date_updated="1700000000000")],
+            },
+        )
+        from unittest.mock import patch
+
+        with patch("clickup.cli.commands.list.get_client", return_value=make_mock_ctx(client)):
+            result = runner.invoke(app, ["--format", "json", "list", "stats", "--workspace-id", "T1"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["data"][0]["id"] == "L2"  # More recent
+        assert payload["data"][1]["id"] == "L1"
+
+    def test_empty_list_handling(self):
+        """Lists with no tasks get task_count 0 and null last_updated, sorting last."""
+        client = _build_client(
+            folderless_lists=[
+                _list(id="L1", name="Active", task_count=5),
+                _list(id="L2", name="Empty", task_count=0),
+            ],
+            tasks_by_list={
+                "L1": [_task(id="t1", name="A", date_updated="1700000000000")],
+                "L2": [],
+            },
+        )
+        from unittest.mock import patch
+
+        with patch("clickup.cli.commands.list.get_client", return_value=make_mock_ctx(client)):
+            result = runner.invoke(app, ["--format", "json", "list", "stats", "--workspace-id", "T1"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        # Empty list should sort last (updated sort, None < any timestamp)
+        assert payload["data"][-1]["id"] == "L2"
+        empty = payload["data"][-1]
+        assert empty["task_count"] == 0
+        assert empty["open_count"] == 0
+        assert empty["last_updated"] is None
+
+    def test_json_shape_matches_spec(self):
+        """JSON output has the envelope shape: {data: [...], count: N}."""
+        client = _build_client(
+            folderless_lists=[_list(id="L1", name="A")],
+            tasks_by_list={"L1": []},
+        )
+        from unittest.mock import patch
+
+        with patch("clickup.cli.commands.list.get_client", return_value=make_mock_ctx(client)):
+            result = runner.invoke(app, ["--format", "json", "list", "stats", "--workspace-id", "T1"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert "data" in payload
+        assert "count" in payload
+        row = payload["data"][0]
+        for key in ("id", "name", "space", "task_count", "open_count", "last_updated"):
+            assert key in row, f"Missing key: {key}"
+
+    def test_no_lists_returns_empty(self):
+        """Workspace with no lists yields empty data array."""
+        client = _build_client(
+            folderless_lists=[],
+            folders=[],
+            tasks_by_list={},
+        )
+        from unittest.mock import patch
+
+        with patch("clickup.cli.commands.list.get_client", return_value=make_mock_ctx(client)):
+            result = runner.invoke(app, ["--format", "json", "list", "stats", "--workspace-id", "T1"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload == {"data": [], "count": 0}
+
+
+# ---------------------------------------------------------------------------
+# Table mode
+# ---------------------------------------------------------------------------
+
+
+class TestListStatsTable:
+    def test_table_escapes_brackets(self):
+        """List names with Rich markup brackets must be escaped."""
+        client = _build_client(
+            folderless_lists=[_list(id="L1", name="[bug] Tracker")],
+            tasks_by_list={"L1": [_task(id="t1", name="X", date_updated="1700000000000")]},
+        )
+        from unittest.mock import patch
+
+        with patch("clickup.cli.commands.list.get_client", return_value=make_mock_ctx(client)):
+            result = runner.invoke(app, ["--format", "table", "list", "stats", "--workspace-id", "T1"])
+
+        assert result.exit_code == 0
+        # The bracket name should appear (not be swallowed by Rich)
+        assert "bug" in result.stdout
+        assert "Tracker" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# --space-id scoping
+# ---------------------------------------------------------------------------
+
+
+class TestListStatsSpaceId:
+    def test_space_id_limits_scope(self):
+        """--space-id limits to one space instead of the full workspace."""
+        client = _build_client(
+            folderless_lists=[_list(id="L1", name="Only One")],
+            tasks_by_list={"L1": [_task(id="t1", name="X", date_updated="1700000000000")]},
+        )
+        from unittest.mock import patch
+
+        with patch("clickup.cli.commands.list.get_client", return_value=make_mock_ctx(client)):
+            result = runner.invoke(app, ["--format", "json", "list", "stats", "--space-id", "S1"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["count"] == 1
+        # When --space-id is used, get_teams/get_spaces should NOT be called
+        client.get_teams.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Error path: task fetch failure is graceful
+# ---------------------------------------------------------------------------
+
+
+class TestListStatsTaskFetchError:
+    def test_task_fetch_error_treated_as_empty(self):
+        """If get_tasks fails for a list, treat it as 0 tasks (fallback to list.task_count)."""
+        client = _build_client(
+            folderless_lists=[_list(id="L1", name="Broken", task_count=42)],
+        )
+        # Override get_tasks to raise
+        client.get_tasks.side_effect = Exception("API error")
+
+        from unittest.mock import patch
+
+        with patch("clickup.cli.commands.list.get_client", return_value=make_mock_ctx(client)):
+            result = runner.invoke(app, ["--format", "json", "list", "stats", "--workspace-id", "T1"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        row = payload["data"][0]
+        # Falls back to list.task_count when tasks can't be fetched
+        assert row["task_count"] == 42
+        assert row["open_count"] == 0
+        assert row["last_updated"] is None
+
+
+# ---------------------------------------------------------------------------
+# help text
+# ---------------------------------------------------------------------------
+
+
+class TestListStatsHelp:
+    def test_stats_in_help(self):
+        """stats subcommand appears in `clickup list --help`."""
+        result = runner.invoke(app, ["list", "--help"])
+        assert result.exit_code == 0
+        assert "stats" in result.stdout

--- a/tests/integration/test_setup_auto.py
+++ b/tests/integration/test_setup_auto.py
@@ -1,0 +1,247 @@
+"""Tests for `clickup setup run --auto` — fully automatic setup."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from clickup.cli.main import app
+
+from .conftest import make_mock_ctx, named_mock
+
+runner = CliRunner()
+
+
+def _named(**kw):
+    return named_mock(**kw)
+
+
+def _mock_client(*, validate_ok=True, teams=None, spaces=None, lists=None, folders=None):
+    """Build an AsyncMock ClickUpClient with sensible defaults."""
+    c = AsyncMock()
+    c.validate_auth.return_value = (
+        validate_ok,
+        "ok" if validate_ok else "bad token",
+        _named(id=1, username="evan", email="evan@example.com") if validate_ok else None,
+    )
+    c.get_teams.return_value = teams or []
+    c.get_spaces.return_value = spaces or []
+    c.get_folders.return_value = folders or []
+    c.get_lists.return_value = []
+    c.get_folderless_lists.return_value = lists or []
+    c.get_list.return_value = (lists or [_named(id="L1", name="X", task_count=0)])[0]
+    return c
+
+
+def _ctx(client):
+    return make_mock_ctx(client)
+
+
+# ---------------------------------------------------------------------------
+# Happy path: single workspace/space/list
+# ---------------------------------------------------------------------------
+
+
+class TestAutoSingleOption:
+    @patch("clickup.cli.commands.setup.ClickUpClient")
+    def test_single_everything_auto_selects(self, mock_cls):
+        """Single workspace + space + list: auto picks all, no prompt."""
+        team = _named(id="T1", name="Acme")
+        space = _named(id="S1", name="Engineering")
+        lst = _named(id="L1", name="Sprint", task_count=10)
+        client = _mock_client(teams=[team], spaces=[space], lists=[lst])
+        mock_cls.return_value = _ctx(client)
+
+        result = runner.invoke(
+            app,
+            ["--format", "json", "setup", "run", "--auto", "--token", "pk_test"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["default_team_id"] == "T1"
+        assert payload["default_space_id"] == "S1"
+        assert payload["default_list_id"] == "L1"
+        assert payload["default_list_name"] == "Sprint"
+
+
+# ---------------------------------------------------------------------------
+# Multiple lists: picks max task_count and warns on stderr
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMultipleLists:
+    @patch("clickup.cli.commands.setup.ClickUpClient")
+    def test_picks_max_task_count_list(self, mock_cls):
+        """With multiple lists, auto picks the one with the most tasks."""
+        team = _named(id="T1", name="Acme")
+        space = _named(id="S1", name="Eng")
+        lists = [
+            _named(id="L1", name="Few", task_count=2),
+            _named(id="L2", name="Many", task_count=20),
+            _named(id="L3", name="Some", task_count=5),
+        ]
+        client = _mock_client(teams=[team], spaces=[space], lists=lists)
+        mock_cls.return_value = _ctx(client)
+
+        result = runner.invoke(
+            app,
+            ["--format", "json", "setup", "run", "--auto", "--token", "pk_test"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["default_list_id"] == "L2"
+        assert payload["default_list_name"] == "Many"
+
+    @patch("clickup.cli.commands.setup.ClickUpClient")
+    def test_warns_on_stderr_about_auto_selection(self, mock_cls):
+        """Auto-selected list emits a warning on stderr."""
+        team = _named(id="T1", name="Acme")
+        space = _named(id="S1", name="Eng")
+        lists = [
+            _named(id="L1", name="Few", task_count=2),
+            _named(id="L2", name="Many", task_count=20),
+        ]
+        client = _mock_client(teams=[team], spaces=[space], lists=lists)
+        mock_cls.return_value = _ctx(client)
+
+        result = runner.invoke(
+            app,
+            ["--format", "json", "setup", "run", "--auto", "--token", "pk_test"],
+        )
+        assert result.exit_code == 0
+        # render_message("warn") goes to stderr in JSON mode
+        assert "Auto-selected" in result.stderr or "Auto-selected" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Multiple workspaces without --team-id: exits 2
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMultipleWorkspaces:
+    @patch("clickup.cli.commands.setup.ClickUpClient")
+    def test_exits_2_listing_options(self, mock_cls):
+        teams = [_named(id="T1", name="A"), _named(id="T2", name="B")]
+        client = _mock_client(teams=teams)
+        mock_cls.return_value = _ctx(client)
+
+        result = runner.invoke(app, ["setup", "run", "--auto", "--token", "pk_test"])
+        assert result.exit_code == 2
+        assert "--team-id" in result.output or "--team-id" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Multiple spaces without --space-id: exits 2
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMultipleSpaces:
+    @patch("clickup.cli.commands.setup.ClickUpClient")
+    def test_exits_2(self, mock_cls):
+        team = _named(id="T1", name="Acme")
+        spaces = [_named(id="S1", name="Eng"), _named(id="S2", name="Design")]
+        client = _mock_client(teams=[team], spaces=spaces)
+        mock_cls.return_value = _ctx(client)
+
+        result = runner.invoke(app, ["setup", "run", "--auto", "--token", "pk_test"])
+        assert result.exit_code == 2
+        assert "--space-id" in result.output or "--space-id" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Explicit flags override auto-selection
+# ---------------------------------------------------------------------------
+
+
+class TestAutoExplicitFlags:
+    @patch("clickup.cli.commands.setup.ClickUpClient")
+    def test_team_id_overrides(self, mock_cls):
+        teams = [_named(id="T1", name="A"), _named(id="T2", name="B")]
+        space = _named(id="S1", name="Eng")
+        lst = _named(id="L1", name="Sprint", task_count=5)
+        client = _mock_client(teams=teams, spaces=[space], lists=[lst])
+        mock_cls.return_value = _ctx(client)
+
+        result = runner.invoke(
+            app,
+            ["--format", "json", "setup", "run", "--auto", "--token", "pk_test", "--team-id", "T2"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["default_team_id"] == "T2"
+
+    @patch("clickup.cli.commands.setup.ClickUpClient")
+    def test_space_id_overrides(self, mock_cls):
+        team = _named(id="T1", name="A")
+        spaces = [_named(id="S1", name="X"), _named(id="S2", name="Y")]
+        lst = _named(id="L1", name="Sprint", task_count=5)
+        client = _mock_client(teams=[team], spaces=spaces, lists=[lst])
+        mock_cls.return_value = _ctx(client)
+
+        result = runner.invoke(
+            app,
+            ["--format", "json", "setup", "run", "--auto", "--token", "pk_test", "--space-id", "S2"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["default_space_id"] == "S2"
+
+    @patch("clickup.cli.commands.setup.ClickUpClient")
+    def test_list_id_overrides(self, mock_cls):
+        team = _named(id="T1", name="A")
+        space = _named(id="S1", name="X")
+        lists = [
+            _named(id="L1", name="Few", task_count=2),
+            _named(id="L2", name="Many", task_count=20),
+        ]
+        client = _mock_client(teams=[team], spaces=[space], lists=lists)
+        mock_cls.return_value = _ctx(client)
+
+        result = runner.invoke(
+            app,
+            ["--format", "json", "setup", "run", "--auto", "--token", "pk_test", "--list-id", "L1"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        # Explicit --list-id overrides the auto max-tasks pick
+        assert payload["default_list_id"] == "L1"
+
+
+# ---------------------------------------------------------------------------
+# No token: exits 2
+# ---------------------------------------------------------------------------
+
+
+class TestAutoNoToken:
+    @patch("clickup.cli.commands.setup.ClickUpClient")
+    def test_no_token_exits_2(self, mock_cls):
+        result = runner.invoke(app, ["setup", "run", "--auto"])
+        assert result.exit_code == 2
+        assert "token" in result.output.lower() or "token" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# No lists: warns but succeeds
+# ---------------------------------------------------------------------------
+
+
+class TestAutoNoLists:
+    @patch("clickup.cli.commands.setup.ClickUpClient")
+    def test_no_lists_warns_succeeds(self, mock_cls):
+        team = _named(id="T1", name="A")
+        space = _named(id="S1", name="X")
+        client = _mock_client(teams=[team], spaces=[space], lists=[])
+        client.get_folders.return_value = []
+        mock_cls.return_value = _ctx(client)
+
+        result = runner.invoke(
+            app,
+            ["--format", "json", "setup", "run", "--auto", "--token", "pk_test"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert "default_list_id" not in payload
+        assert payload["default_team_id"] == "T1"
+        assert payload["default_space_id"] == "S1"

--- a/tests/unit/test_list_stats_renderer.py
+++ b/tests/unit/test_list_stats_renderer.py
@@ -1,0 +1,143 @@
+"""Unit tests for the render_list_stats renderer and updated hint text."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import typer
+
+from clickup.cli.output import FormatChoice, render_list_stats, set_format
+
+
+class TestRenderListStatsJson:
+    def test_json_envelope(self, capsys):
+        set_format(FormatChoice.json)
+        rows = [
+            {
+                "id": "L1",
+                "name": "Sprint",
+                "space": "Eng",
+                "task_count": 5,
+                "open_count": 3,
+                "last_updated": "2025-01-01T00:00:00Z",
+            }
+        ]
+        render_list_stats(rows)
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert payload["count"] == 1
+        assert payload["data"][0]["id"] == "L1"
+        assert payload["data"][0]["task_count"] == 5
+        assert payload["data"][0]["open_count"] == 3
+        assert payload["data"][0]["last_updated"] == "2025-01-01T00:00:00Z"
+
+    def test_empty_list(self, capsys):
+        set_format(FormatChoice.json)
+        render_list_stats([])
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert payload == {"data": [], "count": 0}
+
+    def test_null_last_updated(self, capsys):
+        set_format(FormatChoice.json)
+        rows = [
+            {
+                "id": "L1",
+                "name": "Empty",
+                "space": "Eng",
+                "task_count": 0,
+                "open_count": 0,
+                "last_updated": None,
+            }
+        ]
+        render_list_stats(rows)
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert payload["data"][0]["last_updated"] is None
+
+
+class TestRenderListStatsTable:
+    def test_table_output_has_columns(self, capsys, monkeypatch):
+        from io import StringIO
+
+        from rich.console import Console
+
+        from clickup.cli import output
+
+        buf = StringIO()
+        monkeypatch.setattr(output, "_console", Console(file=buf, force_terminal=False, width=200))
+        set_format(FormatChoice.table)
+
+        rows = [
+            {
+                "id": "L1",
+                "name": "Sprint",
+                "space": "Eng",
+                "task_count": 5,
+                "open_count": 3,
+                "last_updated": "2025-01-01T00:00:00Z",
+            }
+        ]
+        render_list_stats(rows)
+        table_out = buf.getvalue()
+        assert "Sprint" in table_out
+        assert "L1" in table_out
+        assert "5" in table_out
+        assert "3" in table_out
+
+    def test_table_escapes_brackets(self, capsys, monkeypatch):
+        """Names with brackets should not be swallowed by Rich markup."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        from clickup.cli import output
+
+        buf = StringIO()
+        monkeypatch.setattr(output, "_console", Console(file=buf, force_terminal=False, width=200))
+        set_format(FormatChoice.table)
+
+        rows = [
+            {
+                "id": "L1",
+                "name": "[bug] tracker",
+                "space": "Eng",
+                "task_count": 1,
+                "open_count": 1,
+                "last_updated": None,
+            }
+        ]
+        render_list_stats(rows)
+        table_out = buf.getvalue()
+        # Rich should not interpret [bug] as markup — the name should appear
+        assert "bug" in table_out
+        assert "tracker" in table_out
+
+
+class TestRequireListIdHint:
+    def test_hint_mentions_discover(self, capsys):
+        """require_list_id hint now mentions 'clickup discover hierarchy'."""
+        from clickup.cli.output import set_format
+        from clickup.cli.shared import require_list_id
+
+        set_format("json")
+        with pytest.raises(typer.Exit) as exc:
+            require_list_id(None)
+        assert exc.value.exit_code == 2
+        captured = capsys.readouterr()
+        payload = json.loads(captured.err)
+        assert "discover hierarchy" in payload["hint"]
+
+
+class TestStatusHelpText:
+    def test_status_help_mentions_authenticated(self):
+        """status command help text mentions 'authenticated user'."""
+        from typer.testing import CliRunner
+
+        from clickup.cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["status", "--help"])
+        assert result.exit_code == 0
+        assert "authenticated" in result.stdout.lower()


### PR DESCRIPTION
## Summary

Closes the remaining substantive items of #49 ahead of the first suite-v2 agent eval.

- **`clickup list stats`** — enumerates every list (folders + folderless), concurrently fetches tasks (`gather_bounded`), and reports `task_count` / `open_count` / `last_updated` sorted by `--sort updated|tasks`. New `render_list_stats` renderer with the standard `{data, count}` envelope
- **`clickup setup run --auto`** — never prompts: picks singleton workspace/space, picks the largest list when several exist (stderr notice, `--list-id` overrides), persists defaults, emits chosen IDs as JSON. Zero-to-working-`task list` in one command
- Polish: `status` help mentions the authenticated user; missing-list-id hint points at `discover hierarchy`

## Test plan

- [x] `just fc` green (658 passed, coverage 90.3%)
- [x] Smoke-tested both features against the live workspace: stats ranks Personal first by recency; `setup run --auto` → bare `task list` returns 23 tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)