### PR TITLE
Fix comments-add crash, misleading 401, eval cache hardening (0.4.1)

### DIFF
--- a/.claude/skills/cli-agent-eval/SKILL.md
+++ b/.claude/skills/cli-agent-eval/SKILL.md
@@ -22,9 +22,12 @@ When the user asks for an eval / benchmark / agent-usability check, or right aft
    mkdir -p "$(dirname "$CLICKUP_CONFIG_PATH")"
    ```
    This uses the `CLICKUP_CONFIG_PATH` env var (honoured by `Config()`) so the eval's setup wizard, `config set-token`, and any other config writes go to a disposable path instead of `~/.config/clickup-toolkit/config.json`. **Pass this env var to every sub-agent prompt** (see base prompt template below).
-3. **Pre-warm the uvx wheel cache** so 18 parallel agents don't race the build, and so a stale cached wheel can't shadow current source (uvx caches by name+version — see AGENT.md "Local dev caveat"):
-   `uvx --python 3.13 --refresh-package clickup-toolkit --from /home/evan/dev/clickup-tools clickup version`
-   Confirm the reported version matches `pyproject.toml`. If it doesn't, the cache is stale — investigate before dispatching.
+3. **Purge and re-warm the uvx wheel cache.** uvx caches wheels by name+version, and `--refresh-package` only fixes the *refreshing* invocation — the sub-agents' plain `uvx` calls can still resolve the stale archive (this silently invalidated the 2026-06-12 run: agents evaluated a wheel several PRs old while the version number matched). The only reliable sequence is:
+   ```bash
+   uv cache clean clickup-toolkit
+   uvx --python 3.13 --from /home/evan/dev/clickup-tools clickup version
+   ```
+   Then verify freshness with a **behavioral sentinel**, not just the version number: pick a command/flag added by the most recent merged PR and confirm plain `uvx --python 3.13 --from /home/evan/dev/clickup-tools clickup ... --help` shows it. If no recent surface change exists, bump the patch version before the eval so the cache key changes. Do not dispatch until the sentinel passes.
 4. Confirm the user's workspace state. Real values for the eval:
    - User: Evan Oman, ID `150240437`, email `evan058@gmail.com`
    - Workspace: `90131945555` ("Evan Oman's Workspace") — singleton
@@ -191,6 +194,7 @@ After the eval:
 |---|---|---|---|---|
 | 2026-05 (baseline) | v1 (12) | `b8bb6b8` | 10/2/0 | pre-refactor friction batch |
 | 2026-06-11 | v1 (12) | `a22824e` | 11/1/0 | post batches A–G; cmds 84→41 |
+| 2026-06-12 | v2 (18) | `68ad0b2` | **INVALID** | stale uvx wheel (pre-#50 binary); surfaced 2 real bugs anyway: `task comments add` ValidationError, 401-as-"invalid token" on unknown IDs |
 
 Append a row after every run.
 

--- a/clickup/__init__.py
+++ b/clickup/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit - A powerful CLI for ClickUp task management."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 # Import main modules
 from . import cli, core

--- a/clickup/cli/__init__.py
+++ b/clickup/cli/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit CLI - Command-line interface for ClickUp."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from .main import app, main
 

--- a/clickup/cli/commands/task.py
+++ b/clickup/cli/commands/task.py
@@ -499,6 +499,8 @@ def change_status(
     Positional form: clickup task status TASK_ID STATUS
     Flag form (back-compat): clickup task status --task-id TASK_ID --status STATUS
 
+    See valid status values for a list with: clickup task statuses --list-id <id>
+
     Mixing positional + flag for the same parameter is rejected (exit 2) so
     agents don't silently get one value when they thought they passed two.
     """

--- a/clickup/cli/output.py
+++ b/clickup/cli/output.py
@@ -548,7 +548,7 @@ def render_comments(comments: list[Comment]) -> None:
     for comment in comments:
         table.add_row(
             comment.id,
-            escape(comment.user.username),
+            escape(comment.user.username if comment.user else "(unknown)"),
             format_timestamp(comment.date),
             escape(comment.comment_text),
             "Yes" if comment.resolved else "No",
@@ -567,7 +567,7 @@ def render_comment(comment: Comment) -> None:
     table.add_column("Field", style="cyan", width=15)
     table.add_column("Value")
     table.add_row("ID", comment.id)
-    table.add_row("Author", escape(comment.user.username))
+    table.add_row("Author", escape(comment.user.username if comment.user else "(unknown)"))
     table.add_row("Date", format_timestamp(comment.date))
     table.add_row("Comment", escape(comment.comment_text))
     table.add_row("Resolved", "Yes" if comment.resolved else "No")

--- a/clickup/cli/shared.py
+++ b/clickup/cli/shared.py
@@ -109,8 +109,9 @@ def require_list_id(list_id: str | None) -> str:
     usage_error(
         "Error: No list ID provided and no default list configured.",
         hint=(
-            "Use --list-id or set a default with 'clickup config set default_list_id <id>', "
-            "or find IDs with 'clickup discover hierarchy'"
+            "Use --list-id or set a default with 'clickup config set default_list_id <id>' "
+            "(or 'clickup setup run --auto'). Find IDs with 'clickup discover hierarchy', "
+            "or query across lists with 'clickup task search' / 'clickup task mine'."
         ),
     )
 

--- a/clickup/core/client.py
+++ b/clickup/core/client.py
@@ -56,7 +56,18 @@ class ClickUpClient:
                 # No Content (e.g., successful DELETE) — return empty dict
                 return {}
             elif response.status_code == 401:
-                raise AuthenticationError("Invalid API token", response.status_code)
+                try:
+                    error_data = response.json() if response.content else {}
+                except (json.JSONDecodeError, ValueError):
+                    error_data = {}
+                detail = error_data.get("err", "") if isinstance(error_data, dict) else ""
+                raise AuthenticationError(
+                    f"ClickUp rejected the request (401{': ' + detail if detail else ''}). "
+                    "This usually means an invalid API token, but ClickUp also returns 401 "
+                    "for resource IDs that don't exist or aren't accessible to this token. "
+                    "If other commands work, double-check the ID.",
+                    response.status_code,
+                )
             elif response.status_code == 403:
                 raise AuthorizationError("Insufficient permissions", response.status_code)
             elif response.status_code == 404:
@@ -254,10 +265,19 @@ class ClickUpClient:
         return [Comment(**comment) for comment in data.get("comments", [])]
 
     async def create_comment(self, task_id: str, comment_text: str, **kwargs: Any) -> Comment:
-        """Create a comment on a task."""
+        """Create a comment on a task.
+
+        ClickUp's create endpoint returns only ``{id, hist_id, date}``; the
+        rest of the Comment is synthesized from the request payload.
+        """
         payload = {"comment_text": comment_text, **kwargs}
         data = await self._request("POST", f"/task/{task_id}/comment", json=payload)
-        return Comment(**data)
+        return Comment(
+            id=str(data.get("id", "")),
+            comment=[{"text": comment_text}],
+            comment_text=comment_text,
+            date=str(data.get("date", "")),
+        )
 
     # Search
     async def search_tasks(self, team_id: str, query: str, **filters: Any) -> list[Task]:

--- a/clickup/core/models.py
+++ b/clickup/core/models.py
@@ -307,9 +307,10 @@ class Comment(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     id: str
-    comment: list[dict[str, Any]]
+    comment: list[dict[str, Any]] = Field(default_factory=list)
     comment_text: str
-    user: User
+    # ClickUp's create-comment response omits the author; only reads include it.
+    user: User | None = None
     date: str
     resolved: bool = False
 

--- a/evals/68ad0b2-r1-INVALID.json
+++ b/evals/68ad0b2-r1-INVALID.json
@@ -1,0 +1,41 @@
+{
+  "commit": "68ad0b2",
+  "commit_full": "68ad0b2",
+  "timestamp": "2026-06-12T00:35:00-05:00",
+  "suite_version": 2,
+  "invalid": true,
+  "invalid_reason": "Stale uvx wheel cache: agents evaluated a pre-#50 binary (no --format hint, no alias fail-fast, no list stats, no setup --auto) while pyproject version 0.4.0 matched. uvx --refresh-package only refreshed the pre-warm invocation, not the archive plain uvx resolves. Fixed by 'uv cache clean clickup-toolkit' + behavioral sentinel in the skill setup; versions now bump with each change batch.",
+  "summary": {
+    "pass": 13,
+    "partial": 5,
+    "fail": 0,
+    "total_command_count": 66,
+    "total_elapsed_seconds": 1310
+  },
+  "valid_findings": [
+    "task comments add: ClickUpClient.create_comment validated ClickUp's minimal create response {id:int, hist_id, date} against the full Comment model -> pydantic ValidationError; comment created server-side while CLI reported failure (silent mutation + duplicate risk). Bug exists in current code; fixed in follow-up PR.",
+    "401 on unknown task IDs rendered as 'Invalid API token' (AuthenticationError) -- misleading when auth is valid. Message reworded to mention unknown/inaccessible resource IDs; fixed in follow-up PR.",
+    "task create lacks batch mode; done (variadic) vs delete (--task-ids) batch syntax inconsistent -- backlog.",
+    "Zero-result filtered queries give no 'N of M matched' disambiguation -- backlog."
+  ],
+  "tasks": [
+    {"id": 1, "name": "identity", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 15, "top_friction": "none"},
+    {"id": 2, "name": "list teams", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 30, "top_friction": "none"},
+    {"id": 3, "name": "hierarchy", "verdict": "pass", "self_verdict": "pass", "command_count": 3, "elapsed_seconds": 60, "top_friction": "workspace spaces requires -w while discover hierarchy auto-detects"},
+    {"id": 4, "name": "my tasks", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "warn message claim was merged-stream confusion (warn goes to stderr)"},
+    {"id": 5, "name": "sort", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "none"},
+    {"id": 6, "name": "create+delete", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "large JSON blob, no one-line summary"},
+    {"id": 7, "name": "update flow", "verdict": "partial", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 90, "top_friction": "stale binary: misplaced --format gave traceback (fixed in #50, not in evaluated wheel)"},
+    {"id": 8, "name": "search", "verdict": "partial", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 55, "top_friction": "stale binary: --format traceback; count field present but missed"},
+    {"id": 9, "name": "task get+comments", "verdict": "pass", "self_verdict": "pass", "command_count": 3, "elapsed_seconds": 60, "top_friction": "task list unconfigured error could suggest task search"},
+    {"id": 10, "name": "export", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "none"},
+    {"id": 11, "name": "most-active", "verdict": "partial", "self_verdict": "pass", "command_count": 6, "elapsed_seconds": 120, "top_friction": "stale binary: list stats absent from wheel though README mentions it; manual N+1 triangulation"},
+    {"id": 12, "name": "no-flag flow", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 90, "top_friction": "stale binary: setup --auto absent; used --non-interactive with discovered IDs"},
+    {"id": 13, "name": "status workflow", "verdict": "pass", "self_verdict": "pass", "command_count": 6, "elapsed_seconds": 90, "top_friction": "task status help could cross-reference task statuses"},
+    {"id": 14, "name": "batch ops", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 55, "top_friction": "create lacks batch; done/delete batch syntax inconsistent"},
+    {"id": 15, "name": "triage filter", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 120, "top_friction": "stale binary --format traceback; zero-result ambiguity"},
+    {"id": 16, "name": "comment flow", "verdict": "partial", "self_verdict": "partial", "command_count": 6, "elapsed_seconds": 120, "top_friction": "REAL BUG: comments add ValidationError, comment created server-side; api escape hatch needed"},
+    {"id": 17, "name": "error probe", "verdict": "partial", "self_verdict": "pass", "command_count": 7, "elapsed_seconds": 180, "top_friction": "REAL BUG: 401 on unknown task ID reported as Invalid API token"},
+    {"id": 18, "name": "alias flow", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 45, "top_friction": "none"}
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clickup-toolkit"
-version = "0.4.0"
+version = "0.4.1"
 description = "A powerful CLI for ClickUp task management"
 authors = [
     { name = "Evan Oman", email = "evan@example.com" }

--- a/tests/unit/test_core_client.py
+++ b/tests/unit/test_core_client.py
@@ -328,3 +328,37 @@ async def test_timeout_retries_then_raises(mock_sleep, mock_clickup_client):
     # 1 initial + 3 retries = 4 attempts
     assert mock_clickup_client.client.request.call_count == 4
     assert mock_sleep.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_401_message_mentions_resource_ambiguity(mock_clickup_client):
+    """ClickUp returns 401 for unknown resource IDs; the message must say so."""
+    mock_response = Mock()
+    mock_response.status_code = 401
+    mock_response.content = b'{"err": "Team not authorized"}'
+    mock_response.json.return_value = {"err": "Team not authorized"}
+
+    mock_clickup_client.client.request.return_value = mock_response
+
+    with pytest.raises(AuthenticationError) as exc:
+        await mock_clickup_client._request("GET", "/task/doesnotexist123")
+    msg = str(exc.value)
+    assert "Team not authorized" in msg
+    assert "resource IDs" in msg
+
+
+@pytest.mark.asyncio
+async def test_create_comment_handles_minimal_response(mock_clickup_client):
+    """ClickUp's create-comment endpoint returns only {id, hist_id, date}."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.content = b"{}"
+    mock_response.json.return_value = {"id": 458, "hist_id": "abc123", "date": 1568036964079}
+
+    mock_clickup_client.client.request.return_value = mock_response
+
+    comment = await mock_clickup_client.create_comment("task123", "status: looking into it")
+    assert comment.id == "458"
+    assert comment.comment_text == "status: looking into it"
+    assert comment.user is None
+    assert comment.date == "1568036964079"

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-05T04:48:23.193894997Z"
+exclude-newer = "2026-06-05T05:31:47.434248023Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -129,7 +129,7 @@ wheels = [
 
 [[package]]
 name = "clickup-toolkit"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Findings from the first suite-v2 eval run (recorded as INVALID in `evals/68ad0b2-r1-INVALID.json` — the swarm hit a stale uvx wheel — but two real bugs surfaced anyway):

- **`task comments add` crashed** with a pydantic ValidationError: ClickUp's create-comment endpoint returns only `{id, hist_id, date}`, which can't validate as a full `Comment`. Worse, the comment WAS created server-side, so a retrying agent would duplicate it. The client now synthesizes the Comment from the request payload; `Comment.user` is optional and renderers guard it
- **Misleading 401**: unknown task IDs come back from ClickUp as 401, which the CLI reported as "Invalid API token" even with valid auth. The message now includes the API's `err` detail and explains both possibilities
- **Eval integrity**: `uvx --refresh-package` pre-warm doesn't refresh what sub-agents' plain `uvx` resolves; the skill now requires `uv cache clean clickup-toolkit` + a behavioral sentinel before dispatch, and the invalid run is preserved with dispatcher-graded results
- Help polish: `task status` cross-references `task statuses`; missing-list-id hint mentions `setup run --auto` and workspace-wide queries. Version → 0.4.1

## Test plan

- [x] `just fc` green (662 passed, coverage 90.3%)
- [x] New regression tests: minimal create-comment response, 401 message content

🤖 Generated with [Claude Code](https://claude.com/claude-code)