### PR TITLE
Handle typer vendored-click exceptions; align dev lock with fresh installs (0.4.2)

### DIFF
--- a/.claude/skills/cli-agent-eval/SKILL.md
+++ b/.claude/skills/cli-agent-eval/SKILL.md
@@ -27,7 +27,8 @@ When the user asks for an eval / benchmark / agent-usability check, or right aft
    uv cache clean clickup-toolkit
    uvx --python 3.13 --from /home/evan/dev/clickup-tools clickup version
    ```
-   Then verify freshness with a **behavioral sentinel**, not just the version number: pick a command/flag added by the most recent merged PR and confirm plain `uvx --python 3.13 --from /home/evan/dev/clickup-tools clickup ... --help` shows it. If no recent surface change exists, bump the patch version before the eval so the cache key changes. Do not dispatch until the sentinel passes.
+   If `uv cache clean` times out on the cache lock (concurrent uv processes hold it), bump the patch version instead — a new version is a new cache key, which sidesteps the stale archive entirely.
+   Then verify freshness with a **behavioral sentinel**, not just the version number: pick a command/flag added by the most recent merged PR and confirm plain `uvx --python 3.13 --from /home/evan/dev/clickup-tools clickup ... --help` shows it. A good standing sentinel: `clickup task list --list-id 1 --format json` must emit a one-line JSON error envelope with a hint (not a rich traceback). Do not dispatch until the sentinel passes.
 4. Confirm the user's workspace state. Real values for the eval:
    - User: Evan Oman, ID `150240437`, email `evan058@gmail.com`
    - Workspace: `90131945555` ("Evan Oman's Workspace") — singleton

--- a/clickup/__init__.py
+++ b/clickup/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit - A powerful CLI for ClickUp task management."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 # Import main modules
 from . import cli, core

--- a/clickup/cli/__init__.py
+++ b/clickup/cli/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit CLI - Command-line interface for ClickUp."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 from .main import app, main
 

--- a/clickup/cli/main.py
+++ b/clickup/cli/main.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import sys
+from typing import Any, cast
 
 import click
 import typer
@@ -21,7 +22,41 @@ app = typer.Typer(
     add_completion=False,
     rich_markup_mode="rich",
     epilog="New here? Run [bold]clickup setup[/bold] to get started.",
+    # Rich tracebacks on stderr drown the structured error envelope agents
+    # parse; main() below renders all expected errors itself.
+    pretty_exceptions_enable=False,
 )
+
+# Newer typer releases vendor click (typer._click) when the installed click is
+# incompatible; exceptions raised during parsing then come from the vendored
+# module and are NOT subclasses of the real click's exception classes. Catch
+# both families so main()'s envelope/exit-code contract holds in every
+# resolution (this bit us via uvx: dev had typer 0.16/real click, fresh
+# installs got typer 0.26/vendored click and raw tracebacks).
+try:
+    from typer import _click as _typer_click
+
+    _USAGE_ERROR_TYPES: tuple[type[BaseException], ...] = (
+        click.exceptions.UsageError,
+        _typer_click.exceptions.UsageError,
+    )
+    _CLICK_EXCEPTION_TYPES: tuple[type[BaseException], ...] = (
+        click.exceptions.ClickException,
+        _typer_click.exceptions.ClickException,
+    )
+    _ABORT_TYPES: tuple[type[BaseException], ...] = (
+        click.exceptions.Abort,
+        _typer_click.exceptions.Abort,
+    )
+    _EXIT_TYPES: tuple[type[BaseException], ...] = (
+        click.exceptions.Exit,
+        _typer_click.exceptions.Exit,
+    )
+except (ImportError, AttributeError):
+    _USAGE_ERROR_TYPES = (click.exceptions.UsageError,)
+    _CLICK_EXCEPTION_TYPES = (click.exceptions.ClickException,)
+    _ABORT_TYPES = (click.exceptions.Abort,)
+    _EXIT_TYPES = (click.exceptions.Exit,)
 
 _FORMAT_OPTION = typer.Option(
     None,
@@ -266,7 +301,7 @@ def _wants_json_mode(argv: list[str]) -> bool:
     return True
 
 
-def _format_hint(exc: click.ClickException) -> str | None:
+def _format_hint(exc: Any) -> str | None:
     """Return a targeted hint when --format is misplaced after a subcommand.
 
     ``--format`` is a global flag on the root Typer callback. When agents
@@ -280,7 +315,7 @@ def _format_hint(exc: click.ClickException) -> str | None:
     return None
 
 
-def _emit_click_error_envelope(exc: click.ClickException) -> None:
+def _emit_click_error_envelope(exc: Any) -> None:
     """Render a click.ClickException as the canonical JSON error envelope.
 
     This closes the last gap from issue #29 P0 #2: Typer/Click usage errors
@@ -313,31 +348,34 @@ def main() -> None:
         result = app(standalone_mode=False)
         if isinstance(result, int) and result != 0:
             sys.exit(result)
-    except click.exceptions.UsageError as e:
+    except _USAGE_ERROR_TYPES as e:
+        usage_exc = cast(Any, e)
         if json_mode:
-            _emit_click_error_envelope(e)
+            _emit_click_error_envelope(usage_exc)
         else:
-            e.show()
-            hint = _format_hint(e)
+            usage_exc.show()
+            hint = _format_hint(usage_exc)
             if hint:
                 typer.echo(f"Hint: {hint}", err=True)
-        sys.exit(e.exit_code or 2)
-    except click.exceptions.ClickException as e:
+        sys.exit(usage_exc.exit_code or 2)
+    except _CLICK_EXCEPTION_TYPES as e:
         # UsageError + its subclasses (NoSuchOption, BadParameter, etc.) are
         # caught above; this clause catches the other ClickException branch,
         # most realistically FileError.
+        click_exc = cast(Any, e)
         if json_mode:
-            _emit_click_error_envelope(e)
+            _emit_click_error_envelope(click_exc)
         else:
-            e.show()
-        sys.exit(e.exit_code or 1)
-    except click.exceptions.Abort:
+            click_exc.show()
+        sys.exit(click_exc.exit_code or 1)
+    except _ABORT_TYPES:
         # Ctrl+C path; mirror Click's default exit code without the noisy
         # Rich traceback typer emits otherwise.
         sys.exit(1)
-    except click.exceptions.Exit as e:
+    except _EXIT_TYPES as e:
         # typer.Exit raises this with an explicit code; honor it.
-        sys.exit(e.exit_code)
+        exit_exc = cast(Any, e)
+        sys.exit(exit_exc.exit_code)
     except KeyboardInterrupt:
         # Match the JSON contract on stderr in JSON mode; Rich prose for humans.
         if json_mode:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clickup-toolkit"
-version = "0.4.1"
+version = "0.4.2"
 description = "A powerful CLI for ClickUp task management"
 authors = [
     { name = "Evan Oman", email = "evan@example.com" }
@@ -22,7 +22,7 @@ dependencies = [
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
-    "typer>=0.12.0",
+    "typer>=0.26.0",
     "rich>=13.0.0",
     "plankapy>=2.2.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -7,8 +7,17 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-05T05:31:47.434248023Z"
+exclude-newer = "2026-06-05T05:45:05.629161282Z"
 exclude-newer-span = "P7D"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
 
 [[package]]
 name = "annotated-types"
@@ -117,19 +126,19 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
 name = "clickup-toolkit"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -160,7 +169,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
-    { name = "typer", specifier = ">=0.12.0" },
+    { name = "typer", specifier = ">=0.26.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -667,17 +676,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.16.0"
+version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Root cause of the "raw traceback on misplaced --format" reports that #50 was supposed to fix: typer ≥0.26 (what fresh `uvx` installs resolve) vendors click as `typer._click`, so parsing errors raise exception classes that are NOT subclasses of `click.exceptions.*` — our `main()` handlers never matched, typer's pretty-exceptions hook dumped a rich traceback, and the JSON envelope/exit-2 contract silently broke for every fresh install. The dev venv pinned typer 0.16 (real click), so all 660 tests passed while the shipped behavior was broken.

- `main()` catches both the real-click and `typer._click` exception families
- Root Typer app sets `pretty_exceptions_enable=False` (no rich tracebacks drowning stderr)
- Dev lock upgraded to typer 0.26.7 / click 8.4.1 — tests now run the same resolution end users get
- Eval skill setup gains a behavioral sentinel (misplaced `--format` must produce the one-line envelope) and a lock-timeout fallback (bump patch version)
- Version → 0.4.2 (cache-key change so uvx serves this build)

Verified end-to-end via fresh uvx: `clickup task list --list-id 1 --format json` → `{"error": ..., "hint": "Global flag --format goes before the subcommand..."}`, no traceback.

## Test plan

- [x] `just fc` green under typer 0.26.7 (660 passed, coverage 90.1%)
- [x] uvx sentinel verified against the fresh wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)