### PR TITLE
Run-2 eval polish: resource errors, variadic delete, --brief mutations (0.4.3)

### DIFF
--- a/.claude/skills/cli-agent-eval/SKILL.md
+++ b/.claude/skills/cli-agent-eval/SKILL.md
@@ -86,7 +86,7 @@ command_count = CLI invocations that did real work (exclude --help calls; count 
 | 6 | "Create a new task titled `agent-test-eval-6 hello world` in the list with ID 901316076590. Report the task ID and URL. Then DELETE it." | create + delete |
 | 7 | "Create a task named `agent-test-eval-7 update-flow` with description `original` in list 901316076590. Update ONLY its priority to 2. Re-fetch and verify name and description are unchanged. Then delete the task." | modify-if-passed |
 | 8 | "Search the workspace for tasks containing the word 'test'. Report the match count and three example titles." | search |
-| 9 | "Pick any existing task. Get its full details and list its comments. Report which fields came back." | task get expansion, comments read |
+| 9 | "Pick any existing task EXCEPT ones named `agent-test-eval-*` (those are ephemeral artifacts of sibling evals and may vanish mid-run). Get its full details and list its comments. Report which fields came back." | task get expansion, comments read |
 | 10 | "Export tasks from any non-empty list to JSON at /tmp/clickup-export-eval-10.json. Then `head -c 500` the file to confirm." | export |
 | 11 | "Find which list is the user's most active (most tasks and most recent activity). Explain how you decided." | list-level stats |
 | 12 | "Starting from zero configuration, end with `clickup task list` working without any flags. If a default isn't set, set one using only non-interactive commands." | onboarding, default resolution |
@@ -105,6 +105,8 @@ Sub-agent self-verdicts are input, not the result. After all reports return, **y
 - **PASS** — goal fully achieved; ≤6 working CLI invocations (excluding `--help`); no manual workaround for something the CLI should do (e.g., piping JSON to python to filter/sort when a flag exists or should exist); no misleading error encountered; cleanup done.
 - **PARTIAL** — goal achieved but with a workaround, >6 working invocations, a misleading/opaque error along the way, or incomplete cleanup.
 - **FAIL** — goal not achieved within budget.
+
+**Cross-agent interference:** the 18 agents run concurrently against one live workspace, so a read agent can race a sibling's create/delete (e.g., `task search` returns a task that a write agent deletes seconds later). Commands spent recovering from such interference measure the harness, not the CLI — exclude them from the ≤6 budget, but record the incident verbatim in the run notes. Never use this clause to excuse friction the CLI itself caused; when in doubt, count the command.
 
 **Per-task success criteria:**
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup --help
 Four-command happy path:
 
 ```bash
-# 1. Interactive setup -- stores your API token and picks defaults
-uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup setup
+# 1. Non-interactive setup -- with CLICKUP_API_KEY in the env or .env, this
+#    auto-picks your workspace/space/list (agents: always prefer --auto;
+#    humans can drop the flag for interactive prompts)
+uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup setup run --auto
 
 # 2. Verify everything works
 uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup status
@@ -83,14 +85,15 @@ Before configuring aliases, find the numeric list IDs for the lists you want age
 clickup discover hierarchy          # prints workspace > space > folder > list tree with IDs
 ```
 
-Or use `clickup setup run --non-interactive --token <token> --team-id <id> --space-id <id> --list-id <id>` for fully scriptable setup.
+Or skip discovery entirely: `clickup setup run --auto` picks the only workspace/space automatically (and the largest list when several exist) — zero-to-working `clickup task list` in one non-interactive command. Pass explicit `--team-id/--space-id/--list-id` to override any level, or use `--non-interactive` with all IDs for fully pinned setup.
 
 ### 4. Configure aliases for your spaces and a default status
 
 Agents shouldn't have to run discovery commands every time they create a task. Map your real list IDs to short aliases so the agent can route by name:
 
 ```bash
-clickup setup run            # one-shot: picks default workspace/space/list interactively
+clickup setup run --auto     # one-shot non-interactive: auto-picks workspace/space/list
+clickup setup run            # same, but interactive prompts (for humans)
 # or set the alias map by hand:
 clickup config set-default-list omegapoint <list-id>
 clickup config set-default-list overhead <list-id>
@@ -287,8 +290,7 @@ uv run ty check
 
 ### Get started
 - `clickup setup` - Interactive first-run setup (API token + defaults)
-- `clickup status` - Show connection status and configuration
-- `clickup whoami` - Show the authenticated user
+- `clickup status` - Show the authenticated user, connection status, and configuration
 - `clickup config` - Manage configuration and validate credentials
 
 ### Task workflow

--- a/clickup/__init__.py
+++ b/clickup/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit - A powerful CLI for ClickUp task management."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 # Import main modules
 from . import cli, core

--- a/clickup/cli/__init__.py
+++ b/clickup/cli/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit CLI - Command-line interface for ClickUp."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 from .main import app, main
 

--- a/clickup/cli/commands/task.py
+++ b/clickup/cli/commands/task.py
@@ -282,6 +282,7 @@ def create_task(
         "-s",
         help="Initial status (e.g. 'on-deck'). Falls back to config default_status, then list default.",
     ),
+    brief: bool = typer.Option(False, "--brief", help="Return a stripped projection (see `task get --brief`)."),
 ) -> None:
     """Create a new task."""
     validate_task_name(name)
@@ -310,7 +311,7 @@ def create_task(
             async with await get_client() as client:
                 task = await client.create_task(list_id_to_use, **task_data)
                 if get_format() == "json":
-                    render_task(task)
+                    render_task(task, brief=brief)
                     return
                 render_message(f"Created task: {task.name} (ID: {task.id})", "success")
                 if task.url:
@@ -342,6 +343,7 @@ def update_task(
     ),
     due_date: str | None = typer.Option(None, "--due-date", help="New due date (ms timestamp)"),
     archived: bool | None = typer.Option(None, "--archived/--unarchived", help="Archive state"),
+    brief: bool = typer.Option(False, "--brief", help="Return a stripped projection (see `task get --brief`)."),
 ) -> None:
     """Update a task. Only fields you pass are changed; everything else stays the same."""
     validate_priority(priority)
@@ -403,9 +405,9 @@ def update_task(
                         tasks.append(result)
                 if get_format() == "json":
                     if len(tasks) == 1:
-                        render_task(tasks[0])
+                        render_task(tasks[0], brief=brief)
                     else:
-                        render_tasks(tasks)
+                        render_tasks(tasks, brief=brief)
                     return
                 if len(tasks) == 1:
                     render_message(f"Updated task: {tasks[0].name} (ID: {tasks[0].id})", "success")
@@ -415,7 +417,7 @@ def update_task(
     run_async(_update_task())
 
 
-async def _do_status_change_many(task_ids: list[str], status: str) -> None:
+async def _do_status_change_many(task_ids: list[str], status: str, *, brief: bool = False) -> None:
     """Shared implementation for `task status` and short verb aliases.
 
     Each task is attempted independently — one bad ID doesn't abort the rest
@@ -442,9 +444,9 @@ async def _do_status_change_many(task_ids: list[str], status: str) -> None:
     if succeeded:
         if get_format() == "json":
             if len(task_ids) == 1:
-                render_task(succeeded[0])
+                render_task(succeeded[0], brief=brief)
             else:
-                render_tasks(succeeded)
+                render_tasks(succeeded, brief=brief)
         elif len(succeeded) == 1 and not failures:
             render_message(f"Updated task status: {succeeded[0].name} -> {status}", "success")
         else:
@@ -493,6 +495,7 @@ def change_status(
     status_flag: str | None = typer.Option(
         None, "--status", "-s", help="New status (back-compat alias for positional)"
     ),
+    brief: bool = typer.Option(False, "--brief", help="Return a stripped projection (see `task get --brief`)."),
 ) -> None:
     """Change task status.
 
@@ -522,25 +525,27 @@ def change_status(
 
     # Type-narrow for the type checker; the _usage_error calls above raise on None.
     assert status is not None
-    run_async(_do_status_change_many(task_ids, status))
+    run_async(_do_status_change_many(task_ids, status, brief=brief))
 
 
 @app.command("done")
 def task_done(
     task_ids: list[str] = typer.Argument(..., metavar="TASK_ID...", help="One or more task IDs"),
     status: str = typer.Option(_DONE_STATUS, "--status", "-s", help=f"Target status name (default: '{_DONE_STATUS}')"),
+    brief: bool = typer.Option(False, "--brief", help="Return a stripped projection (see `task get --brief`)."),
 ) -> None:
     """Close one or more tasks. Sets status to 'complete' unless --status overrides."""
-    run_async(_do_status_change_many(task_ids, status))
+    run_async(_do_status_change_many(task_ids, status, brief=brief))
 
 
 @app.command("close")
 def task_close(
     task_ids: list[str] = typer.Argument(..., metavar="TASK_ID...", help="One or more task IDs"),
     status: str = typer.Option(_DONE_STATUS, "--status", "-s", help=f"Target status name (default: '{_DONE_STATUS}')"),
+    brief: bool = typer.Option(False, "--brief", help="Return a stripped projection (see `task get --brief`)."),
 ) -> None:
     """Close one or more tasks. Alias for `task done`."""
-    run_async(_do_status_change_many(task_ids, status))
+    run_async(_do_status_change_many(task_ids, status, brief=brief))
 
 
 @app.command("start")
@@ -549,24 +554,30 @@ def task_start(
     status: str = typer.Option(
         _START_STATUS, "--status", "-s", help=f"Target status name (default: '{_START_STATUS}')"
     ),
+    brief: bool = typer.Option(False, "--brief", help="Return a stripped projection (see `task get --brief`)."),
 ) -> None:
     """Move one or more tasks to 'in progress' unless --status overrides."""
-    run_async(_do_status_change_many(task_ids, status))
+    run_async(_do_status_change_many(task_ids, status, brief=brief))
 
 
 @app.command("park")
 def task_park(
     task_ids: list[str] = typer.Argument(..., metavar="TASK_ID...", help="One or more task IDs"),
     status: str = typer.Option(_PARK_STATUS, "--status", "-s", help=f"Target status name (default: '{_PARK_STATUS}')"),
+    brief: bool = typer.Option(False, "--brief", help="Return a stripped projection (see `task get --brief`)."),
 ) -> None:
     """Park one or more tasks on the on-deck queue unless --status overrides."""
-    run_async(_do_status_change_many(task_ids, status))
+    run_async(_do_status_change_many(task_ids, status, brief=brief))
 
 
 @app.command("delete")
 def delete_task(
-    task_id: str | None = typer.Argument(None, help="Task ID"),
-    task_ids: str | None = typer.Option(None, "--task-ids", help="Comma-separated task IDs to delete"),
+    task_ids_args: list[str] | None = typer.Argument(
+        None,
+        metavar="TASK_ID...",
+        help="One or more task IDs to delete",
+    ),
+    task_ids: str | None = typer.Option(None, "--task-ids", help="Comma-separated task IDs to delete (back-compat)"),
     force: bool = typer.Option(
         False,
         "--force",
@@ -578,14 +589,16 @@ def delete_task(
 ) -> None:
     """Delete one or more tasks.
 
-    Positional form: clickup task delete TASK_ID --force
-    Batch form: clickup task delete --task-ids ID1,ID2 --force
+    Positional form: clickup task delete ID1 ID2 ID3 --force
+    Flag form (back-compat): clickup task delete --task-ids ID1,ID2 --force
     """
 
     async def _delete_task() -> None:
-        if task_id is not None and task_ids is not None:
-            usage_error("Error: pass TASK_ID either as a positional argument OR via --task-ids, not both.")
-        target_ids = [task_id] if task_id is not None else split_csv(task_ids)
+        has_positional = bool(task_ids_args)
+        has_flag = task_ids is not None
+        if has_positional and has_flag:
+            usage_error("Error: pass TASK_ID either as positional arguments OR via --task-ids, not both.")
+        target_ids = list(task_ids_args or []) if has_positional else split_csv(task_ids)
         if not target_ids:
             usage_error("Error: Task ID or --task-ids is required.")
 

--- a/clickup/core/__init__.py
+++ b/clickup/core/__init__.py
@@ -13,6 +13,7 @@ from .exceptions import (
     NotFoundError,
     RateLimitError,
     RequestTimeoutError,
+    ResourceAccessError,
     ServerError,
     ValidationError,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "ClickUpError",
     "AuthenticationError",
     "AuthorizationError",
+    "ResourceAccessError",
     "NotFoundError",
     "RateLimitError",
     "ServerError",

--- a/clickup/core/client.py
+++ b/clickup/core/client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import re
 from typing import Any
 from urllib.parse import urljoin
 
@@ -17,6 +18,7 @@ from .exceptions import (
     NotFoundError,
     RateLimitError,
     RequestTimeoutError,
+    ResourceAccessError,
     ServerError,
     ValidationError,
 )
@@ -46,7 +48,17 @@ class ClickUpClient:
         """Async context manager exit."""
         await self.client.aclose()
 
-    def _handle_response(self, response: httpx.Response) -> dict[str, Any]:
+    # Endpoints that target a specific resource (as opposed to auth-only
+    # endpoints like /user or the bare /team root).  When ClickUp returns
+    # 401 on one of these, the most likely cause is a bad resource ID, not
+    # a bad token — so we raise ResourceAccessError instead of
+    # AuthenticationError.
+    _RESOURCE_ENDPOINT_RE = re.compile(
+        r"^/(?:task|list|folder|space|view)/[^/]"  # /task/<id>, /list/<id>/task, etc.
+        r"|^/team/\d+/.+"  # /team/123/space, /team/123/task, …
+    )
+
+    def _handle_response(self, response: httpx.Response, *, endpoint: str = "") -> dict[str, Any]:
         """Handle HTTP response and raise appropriate exceptions."""
         try:
             if response.status_code in (200, 201):
@@ -61,17 +73,25 @@ class ClickUpClient:
                 except (json.JSONDecodeError, ValueError):
                     error_data = {}
                 detail = error_data.get("err", "") if isinstance(error_data, dict) else ""
-                raise AuthenticationError(
+                message = (
                     f"ClickUp rejected the request (401{': ' + detail if detail else ''}). "
                     "This usually means an invalid API token, but ClickUp also returns 401 "
                     "for resource IDs that don't exist or aren't accessible to this token. "
-                    "If other commands work, double-check the ID.",
+                    "If other commands work, double-check the ID."
+                )
+                if self._RESOURCE_ENDPOINT_RE.search(endpoint):
+                    raise ResourceAccessError(message, response.status_code)
+                raise AuthenticationError(message, response.status_code)
+            elif response.status_code == 403:
+                raise AuthorizationError(
+                    f"Insufficient permissions: {endpoint}" if endpoint else "Insufficient permissions",
                     response.status_code,
                 )
-            elif response.status_code == 403:
-                raise AuthorizationError("Insufficient permissions", response.status_code)
             elif response.status_code == 404:
-                raise NotFoundError("Resource not found", response.status_code)
+                raise NotFoundError(
+                    f"Resource not found: {endpoint}" if endpoint else "Resource not found",
+                    response.status_code,
+                )
             elif response.status_code == 400:
                 error_data = response.json() if response.content else {}
                 raise ValidationError(error_data.get("err", "Bad request"), response.status_code, error_data)
@@ -87,6 +107,9 @@ class ClickUpClient:
 
     async def _request(self, method: str, endpoint: str, **kwargs: Any) -> dict[str, Any]:
         """Make HTTP request with retry logic."""
+        # Preserve the original endpoint (with leading /) for error messages
+        # before normalising it for URL construction.
+        raw_endpoint = endpoint if endpoint.startswith("/") else f"/{endpoint}"
         base_url = self.config.get("base_url")
         # Ensure base_url ends with / and endpoint starts without /
         if not base_url.endswith("/"):
@@ -99,7 +122,7 @@ class ClickUpClient:
         for attempt in range(max_retries + 1):
             try:
                 response = await self.client.request(method, url, **kwargs)
-                return self._handle_response(response)
+                return self._handle_response(response, endpoint=raw_endpoint)
             except RateLimitError as e:
                 if attempt < max_retries:
                     await asyncio.sleep(e.retry_after or 60)

--- a/clickup/core/exceptions.py
+++ b/clickup/core/exceptions.py
@@ -20,6 +20,12 @@ class AuthenticationError(ClickUpError):
     pass
 
 
+class ResourceAccessError(ClickUpError):
+    """401 from a resource endpoint: invalid token OR unknown/inaccessible resource ID."""
+
+    pass
+
+
 class AuthorizationError(ClickUpError):
     """Authorization failed (insufficient permissions)."""
 

--- a/evals/9dc2b5b-r2.json
+++ b/evals/9dc2b5b-r2.json
@@ -1,0 +1,34 @@
+{
+  "commit": "9dc2b5b",
+  "commit_full": "9dc2b5b",
+  "timestamp": "2026-06-12T01:15:00-05:00",
+  "suite_version": 2,
+  "summary": {
+    "pass": 17,
+    "partial": 1,
+    "fail": 0,
+    "total_command_count": 61,
+    "total_elapsed_seconds": 1190
+  },
+  "notes": "First valid suite-v2 run (fresh 0.4.2 wheel, sentinel-verified). setup run --auto cut onboarding from 7 to 2 commands; the misplaced --format hint recovered every occurrence; comments add fixed. Task 9 graded PARTIAL strictly: 8 working commands, but ~4 were recovery from a cross-agent race (task search returned a task a sibling eval agent deleted mid-run) — rubric clarified for future runs to attribute interference-recovery separately.",
+  "tasks": [
+    {"id": 1, "name": "identity", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 30, "top_friction": "README lists 'clickup whoami' which does not exist"},
+    {"id": 2, "name": "list teams", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 30, "top_friction": "none"},
+    {"id": 3, "name": "hierarchy", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 50, "top_friction": "--format placement error, recovered via hint"},
+    {"id": 4, "name": "my tasks", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 45, "top_friction": "none"},
+    {"id": 5, "name": "sort", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "none"},
+    {"id": 6, "name": "create+delete", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "none; suggested --id-only/brief create output"},
+    {"id": 7, "name": "update flow", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 90, "top_friction": "delete --force discovered via clear refusal error (one retry)"},
+    {"id": 8, "name": "search", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "fuzzy full-text semantics documented but may surprise; --format hint recovered"},
+    {"id": 9, "name": "task get+comments", "verdict": "partial", "self_verdict": "pass", "command_count": 8, "elapsed_seconds": 120, "top_friction": "cross-agent race: search returned a sibling agent's just-deleted task; 404 message lacks the resource ID"},
+    {"id": 10, "name": "export", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "none"},
+    {"id": 11, "name": "most-active", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 120, "top_friction": "list stats works (one call per sort key); no composite metric"},
+    {"id": 12, "name": "no-flag flow", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 60, "top_friction": "setup run --auto is ideal but absent from README quickstart"},
+    {"id": 13, "name": "status workflow", "verdict": "pass", "self_verdict": "pass", "command_count": 6, "elapsed_seconds": 90, "top_friction": "status-change response is the full task object; --brief wanted"},
+    {"id": 14, "name": "batch ops", "verdict": "pass", "self_verdict": "pass", "command_count": 6, "elapsed_seconds": 90, "top_friction": "done (variadic) vs delete (--task-ids) batch syntax inconsistency"},
+    {"id": 15, "name": "triage filter", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 90, "top_friction": "--format placement (recovered via hint)"},
+    {"id": 16, "name": "comment flow", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 45, "top_friction": "comments add now works; delete --force cost one retry"},
+    {"id": 17, "name": "error probe", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 90, "top_friction": "401 message text actionable but type=AuthenticationError misleads programmatic consumers"},
+    {"id": 18, "name": "alias flow", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 60, "top_friction": "set-default-list name slightly obscures alias semantics"}
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clickup-toolkit"
-version = "0.4.2"
+version = "0.4.3"
 description = "A powerful CLI for ClickUp task management"
 authors = [
     { name = "Evan Oman", email = "evan@example.com" }

--- a/tests/integration/test_task_commands.py
+++ b/tests/integration/test_task_commands.py
@@ -1028,7 +1028,7 @@ def test_task_delete_both_positional_and_task_ids_exits_2():
     """Passing both positional TASK_ID and --task-ids is a usage error."""
     result = runner.invoke(app, ["task", "delete", "task1", "--task-ids", "task2", "--force"])
     assert result.exit_code == 2
-    assert "either as a positional argument OR via --task-ids" in result.stderr
+    assert "either as positional arguments OR via --task-ids" in result.stderr
 
 
 def test_task_delete_neither_positional_nor_task_ids_exits_2():
@@ -1036,6 +1036,29 @@ def test_task_delete_neither_positional_nor_task_ids_exits_2():
     result = runner.invoke(app, ["task", "delete", "--force"])
     assert result.exit_code == 2
     assert "Task ID or --task-ids is required" in result.stderr
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_delete_variadic_positional(mock_get_client):
+    """Multiple positional IDs produce a collection envelope."""
+    mock_client = AsyncMock()
+    mock_client.delete_task.return_value = True
+
+    def create_mock_client():
+        ctx_mgr = AsyncMock()
+        ctx_mgr.__aenter__.return_value = mock_client
+        return ctx_mgr
+
+    mock_get_client.side_effect = create_mock_client
+
+    result = runner.invoke(app, ["task", "delete", "task1", "task2", "--force"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["count"] == 2
+    assert all(item["deleted"] is True for item in data["data"])
+    assert [item["id"] for item in data["data"]] == ["task1", "task2"]
+    assert mock_client.delete_task.await_count == 2
 
 
 def test_task_delete_batch_without_force_exits_2():
@@ -1555,3 +1578,54 @@ def test_task_list_with_filters_cov(mock_get_client):
     )
     assert result.exit_code == 0
     assert "X" in result.output
+
+
+# =============================================================================
+# --brief on mutation responses (item 4)
+# =============================================================================
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_create_brief_omits_description(mock_get_client):
+    """--brief on create returns the stripped projection (no description)."""
+    mock_client = AsyncMock()
+    mock_client.create_task.return_value = Task(
+        id="t1", name="Brief", description="long detailed text", url="https://x"
+    )
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "create", "Brief", "--list-id", "L1", "--brief"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["id"] == "t1"
+    assert data["name"] == "Brief"
+    assert "description" not in data
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_update_brief_omits_description(mock_get_client):
+    """--brief on update returns the stripped projection (no description)."""
+    mock_client = AsyncMock()
+    mock_client.update_task.return_value = Task(id="t1", name="Updated", description="some desc", url="https://x")
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "update", "t1", "--name", "Updated", "--brief"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["id"] == "t1"
+    assert data["name"] == "Updated"
+    assert "description" not in data
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_task_status_brief_omits_description(mock_get_client):
+    """--brief on status returns the stripped projection (no description)."""
+    mock_client = AsyncMock()
+    mock_client.update_task.return_value = Task(id="t1", name="X", description="verbose desc", url="https://x")
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "status", "t1", "complete", "--brief"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["id"] == "t1"
+    assert "description" not in data

--- a/tests/unit/test_core_client.py
+++ b/tests/unit/test_core_client.py
@@ -13,6 +13,7 @@ from clickup.core import (
     NotFoundError,
     RateLimitError,
     RequestTimeoutError,
+    ResourceAccessError,
     ValidationError,
 )
 
@@ -60,8 +61,9 @@ async def test_not_found_error(mock_clickup_client):
 
     mock_clickup_client.client.request.return_value = mock_response
 
-    with pytest.raises(NotFoundError):
-        await mock_clickup_client._request("GET", "/test")
+    with pytest.raises(NotFoundError) as exc:
+        await mock_clickup_client._request("GET", "/task/86aj0p7b2")
+    assert "/task/86aj0p7b2" in str(exc.value)
 
 
 @pytest.mark.asyncio
@@ -331,8 +333,8 @@ async def test_timeout_retries_then_raises(mock_sleep, mock_clickup_client):
 
 
 @pytest.mark.asyncio
-async def test_401_message_mentions_resource_ambiguity(mock_clickup_client):
-    """ClickUp returns 401 for unknown resource IDs; the message must say so."""
+async def test_401_on_resource_endpoint_raises_resource_access_error(mock_clickup_client):
+    """ClickUp returns 401 for unknown resource IDs; must raise ResourceAccessError."""
     mock_response = Mock()
     mock_response.status_code = 401
     mock_response.content = b'{"err": "Team not authorized"}'
@@ -340,11 +342,25 @@ async def test_401_message_mentions_resource_ambiguity(mock_clickup_client):
 
     mock_clickup_client.client.request.return_value = mock_response
 
-    with pytest.raises(AuthenticationError) as exc:
+    with pytest.raises(ResourceAccessError) as exc:
         await mock_clickup_client._request("GET", "/task/doesnotexist123")
     msg = str(exc.value)
     assert "Team not authorized" in msg
     assert "resource IDs" in msg
+
+
+@pytest.mark.asyncio
+async def test_401_on_user_endpoint_stays_authentication_error(mock_clickup_client):
+    """401 on /user (non-resource endpoint) must stay AuthenticationError."""
+    mock_response = Mock()
+    mock_response.status_code = 401
+    mock_response.content = b'{"err": "Unauthorized"}'
+    mock_response.json.return_value = {"err": "Unauthorized"}
+
+    mock_clickup_client.client.request.return_value = mock_response
+
+    with pytest.raises(AuthenticationError):
+        await mock_clickup_client._request("GET", "/user")
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-05T05:45:05.629161282Z"
+exclude-newer = "2026-06-05T06:06:17.111362204Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "clickup-toolkit"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Fixes everything actionable from the first valid suite-v2 eval run (`evals/9dc2b5b-r2.json`, 17/1/0):

- **404s name the resource**: `Resource not found: /task/<id>` instead of bare "Resource not found"
- **`ResourceAccessError`** on 401 from resource endpoints — programmatic consumers no longer branch on a misleading `AuthenticationError` when the real cause is an unknown/inaccessible ID; auth-root endpoints (`/user`, `/team`) keep `AuthenticationError`
- **`task delete ID1 ID2 ID3 --force`** — variadic positionals matching `task done`; `--task-ids` stays as alias; single-ID flat output unchanged
- **`--brief` on every mutation** (create/update/status/done/close/start/park) for compact confirmations
- README: ghost `whoami` removed; `setup run --auto` promoted to the quickstart happy path
- Eval suite: task 9 avoids ephemeral `agent-test-eval-*` artifacts; rubric gains a tightly-bounded cross-agent-interference clause

## Test plan

- [x] `just fc` green (665 passed, coverage 90.1%)
- [x] New tests: endpoint-in-404, ResourceAccessError vs AuthenticationError split, variadic delete shapes + mixing guard, --brief projections

🤖 Generated with [Claude Code](https://claude.com/claude-code)