### PR TITLE
Accept --format anywhere; per-agent eval config isolation (0.4.4)

### DIFF
--- a/.claude/skills/cli-agent-eval/SKILL.md
+++ b/.claude/skills/cli-agent-eval/SKILL.md
@@ -16,12 +16,13 @@ When the user asks for an eval / benchmark / agent-usability check, or right aft
 ## Setup checks (do these first, in parallel)
 
 1. Confirm `.env` exists at project root with a real `CLICKUP_API_KEY`. If missing, stop and ask the user to provide one.
-2. **Isolate eval config from real user config.** Run:
+2. **Isolate eval config from real user config — one path PER SUB-AGENT.** Create a base dir, then give every sub-agent its own file:
    ```bash
-   export CLICKUP_CONFIG_PATH="/tmp/clickup-eval-$(date +%s)/config.json"
-   mkdir -p "$(dirname "$CLICKUP_CONFIG_PATH")"
+   EVAL_CFG_BASE="/tmp/clickup-eval-$(date +%s)"
+   mkdir -p "$EVAL_CFG_BASE"
+   # sub-agent N gets: CLICKUP_CONFIG_PATH="$EVAL_CFG_BASE/config-task<N>.json"
    ```
-   This uses the `CLICKUP_CONFIG_PATH` env var (honoured by `Config()`) so the eval's setup wizard, `config set-token`, and any other config writes go to a disposable path instead of `~/.config/clickup-toolkit/config.json`. **Pass this env var to every sub-agent prompt** (see base prompt template below).
+   The env var is honoured by `Config()`, so writes never touch `~/.config/clickup-toolkit/config.json`. Per-agent paths matter: several tasks WRITE config (`setup run --auto`, aliases), and `save_config()` rewrites the whole file — 18 concurrent agents sharing one path clobber each other's defaults (this produced a phantom "setup --auto doesn't persist" finding in the 2026-06-12 r3 run). Substitute the per-agent path into each prompt's `{CLICKUP_CONFIG_PATH}`.
 3. **Purge and re-warm the uvx wheel cache.** uvx caches wheels by name+version, and `--refresh-package` only fixes the *refreshing* invocation — the sub-agents' plain `uvx` calls can still resolve the stale archive (this silently invalidated the 2026-06-12 run: agents evaluated a wheel several PRs old while the version number matched). The only reliable sequence is:
    ```bash
    uv cache clean clickup-toolkit

--- a/AGENT.md
+++ b/AGENT.md
@@ -115,7 +115,7 @@ JSON shape:
 
 ### 2. `--format` is a GLOBAL flag, not per-command
 
-Wired on the root Typer callback in `main.py`. **JSON is the default** — agents are first-class consumers, so the unflagged path emits structured data. Pass `clickup --format table <subcommand> ...` for human-readable output. Per-subcommand `--format` would conflict and confuse agents. Both `task export` and `bulk export-tasks` use `--output-format` for the output FILE format (json/csv), which is unrelated to the global `--format`. `bulk export-tasks` retains `--format` as a deprecated alias for backward compatibility.
+Wired on the root Typer callback in `main.py`. **JSON is the default** — agents are first-class consumers, so the unflagged path emits structured data. Pass `clickup --format table <subcommand> ...` for human-readable output. Since v0.4.4 the flag is also **accepted after the subcommand**: `main()` hoists a trailing `--format <value>` to the front before parsing (`_hoist_global_format`), because agent evals showed 7 of 18 fresh agents instinctively append it. The hoist is skipped for `export-tasks`, whose own `--format` alias (output FILE format, csv/json — deprecated alias of `--output-format`) must keep its local meaning; `task export` uses only `--output-format`. Don't declare `--format` on any new subcommand — the hoist plus root callback already covers it.
 
 ### 3. Modify-if-passed update semantics
 

--- a/clickup/__init__.py
+++ b/clickup/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit - A powerful CLI for ClickUp task management."""
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 
 # Import main modules
 from . import cli, core

--- a/clickup/cli/__init__.py
+++ b/clickup/cli/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit CLI - Command-line interface for ClickUp."""
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 
 from .main import app, main
 

--- a/clickup/cli/main.py
+++ b/clickup/cli/main.py
@@ -21,7 +21,7 @@ app = typer.Typer(
     help="ClickUp CLI - Task management from the command line.",
     add_completion=False,
     rich_markup_mode="rich",
-    epilog="New here? Run [bold]clickup setup[/bold] to get started.",
+    epilog="New here? Run [bold]clickup setup run --auto[/bold] to get started non-interactively.",
     # Rich tracebacks on stderr drown the structured error envelope agents
     # parse; main() below renders all expected errors itself.
     pretty_exceptions_enable=False,
@@ -284,6 +284,34 @@ async def async_main() -> None:
     app()
 
 
+def _hoist_global_format(argv: list[str]) -> list[str]:
+    """Move a trailing ``--format <value>`` to the front so it parses globally.
+
+    Agents overwhelmingly append flags (``clickup task list --format json``),
+    but ``--format`` lives on the root callback. Rewriting argv accepts the
+    flag in any position instead of erroring. Skipped when:
+
+    * ``--format`` already appears before the subcommand (nothing to do), or
+    * the invocation targets ``export-tasks``, whose own ``--format`` alias
+      (file format, csv/json) must keep its local meaning.
+    """
+    if "export-tasks" in argv:
+        return argv
+    subcommand_idx = next((i for i, a in enumerate(argv) if not a.startswith("-")), None)
+    if subcommand_idx is None:
+        return argv
+    for i, arg in enumerate(argv):
+        if i < subcommand_idx and (arg == "--format" or arg.startswith("--format=")):
+            return argv
+    for i in range(subcommand_idx, len(argv)):
+        arg = argv[i]
+        if arg.startswith("--format="):
+            return [arg, *argv[:i], *argv[i + 1 :]]
+        if arg == "--format" and i + 1 < len(argv):
+            return [arg, argv[i + 1], *argv[:i], *argv[i + 2 :]]
+    return argv
+
+
 def _wants_json_mode(argv: list[str]) -> bool:
     """Inspect argv for ``--format`` before Click parses it.
 
@@ -338,6 +366,7 @@ def main() -> None:
     usage errors through the structured JSON envelope agents expect, instead
     of letting Click format them as Rich prose on stderr.
     """
+    sys.argv[1:] = _hoist_global_format(sys.argv[1:])
     json_mode = _wants_json_mode(sys.argv[1:])
     try:
         # In non-standalone mode Click *returns* the exit code when a command

--- a/evals/afe5e5f-r3.json
+++ b/evals/afe5e5f-r3.json
@@ -1,0 +1,34 @@
+{
+  "commit": "afe5e5f",
+  "commit_full": "afe5e5f",
+  "timestamp": "2026-06-12T01:55:00-05:00",
+  "suite_version": 2,
+  "summary": {
+    "pass": 18,
+    "partial": 0,
+    "fail": 0,
+    "total_command_count": 60,
+    "total_elapsed_seconds": 1140
+  },
+  "notes": "First 18/18 run (v0.4.3). Task 9 passes via the documented interference clause: its 'setup --auto does not persist' finding was a harness bug — all 18 agents shared ONE config file, so concurrent save_config() writes clobbered each other (agent 12 ran the identical flow successfully). Harness fixed to per-agent config paths for future runs. Recurring CLI friction: misplaced --format hit 7/18 agents (hint recovered every occurrence) — eliminated in v0.4.4 via argv hoisting. Backlog ideas logged: batch create, --sort activity composite, search --count, export filename default, alias display in config show.",
+  "tasks": [
+    {"id": 1, "name": "identity", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 15, "top_friction": "none"},
+    {"id": 2, "name": "list teams", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 45, "top_friction": "none"},
+    {"id": 3, "name": "hierarchy", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 60, "top_friction": "--format placement (hint recovered)"},
+    {"id": 4, "name": "my tasks", "verdict": "pass", "self_verdict": "pass", "command_count": 3, "elapsed_seconds": 45, "top_friction": "none"},
+    {"id": 5, "name": "sort", "verdict": "pass", "self_verdict": "pass", "command_count": 3, "elapsed_seconds": 45, "top_friction": "none"},
+    {"id": 6, "name": "create+delete", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "none; zero failed attempts"},
+    {"id": 7, "name": "update flow", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 75, "top_friction": "--format placement (hint recovered); priority null-vs-int representation note"},
+    {"id": 8, "name": "search", "verdict": "pass", "self_verdict": "pass", "command_count": 3, "elapsed_seconds": 45, "top_friction": "default search output verbose; --brief solved it"},
+    {"id": 9, "name": "task get+comments", "verdict": "pass", "self_verdict": "pass", "command_count": 7, "elapsed_seconds": 90, "top_friction": "HARNESS: shared config file clobbered by sibling agents made setup --auto look broken; interference clause applied (effective ~4 cmds)"},
+    {"id": 10, "name": "export", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "default output filename stays tasks.csv with --format json"},
+    {"id": 11, "name": "most-active", "verdict": "pass", "self_verdict": "pass", "command_count": 3, "elapsed_seconds": 90, "top_friction": "no composite activity sort; two list stats calls"},
+    {"id": 12, "name": "no-flag flow", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 60, "top_friction": "epilog hint said 'clickup setup' not 'setup run --auto' (fixed in 0.4.4)"},
+    {"id": 13, "name": "status workflow", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 90, "top_friction": "none; --brief used throughout"},
+    {"id": 14, "name": "batch ops", "verdict": "pass", "self_verdict": "pass", "command_count": 6, "elapsed_seconds": 75, "top_friction": "--format placement; no batch create (criteria only requires batched close+delete)"},
+    {"id": 15, "name": "triage filter", "verdict": "pass", "self_verdict": "pass", "command_count": 3, "elapsed_seconds": 90, "top_friction": "--format placement (hint recovered)"},
+    {"id": 16, "name": "comment flow", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 45, "top_friction": "none; zero errors"},
+    {"id": 17, "name": "error probe", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 90, "top_friction": "ResourceAccessError type debated; message text judged fully actionable"},
+    {"id": 18, "name": "alias flow", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 60, "top_friction": "alias map not shown in config show"}
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clickup-toolkit"
-version = "0.4.3"
+version = "0.4.4"
 description = "A powerful CLI for ClickUp task management"
 authors = [
     { name = "Evan Oman", email = "evan@example.com" }

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -384,20 +384,16 @@ class TestFormatHint:
         assert _format_hint(exc) is None
 
 
-def test_main_format_after_subcommand_json_envelope(
+def test_main_format_after_subcommand_now_works(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """``clickup task search --format json`` (default mode) emits JSON envelope with hint on stderr."""
-    monkeypatch.setattr("sys.argv", ["clickup", "task", "search", "--query", "x", "--format", "json"])
-    with pytest.raises(SystemExit) as exit_info:
-        main()
-    assert exit_info.value.code == 2
+    """``clickup version --format json`` (trailing global flag) is hoisted and succeeds."""
+    monkeypatch.setattr("sys.argv", ["clickup", "version", "--format", "json"])
+    main()
     captured = capsys.readouterr()
-    payload = json.loads(captured.err)
-    assert payload["type"] == "NoSuchOption"
-    assert "hint" in payload
-    assert "before the subcommand" in payload["hint"]
+    payload = json.loads(captured.out)
+    assert payload["name"] == "ClickUp Toolkit CLI"
 
 
 def test_main_format_after_subcommand_table_mode_hint(
@@ -427,3 +423,53 @@ def test_main_unknown_option_no_format_hint(
     captured = capsys.readouterr()
     payload = json.loads(captured.err)
     assert "hint" not in payload
+
+
+class TestHoistGlobalFormat:
+    """--format is accepted in any position (hoisted to the root parser)."""
+
+    def test_trailing_format_pair_hoisted(self):
+        from clickup.cli.main import _hoist_global_format
+
+        assert _hoist_global_format(["task", "list", "--format", "table"]) == [
+            "--format",
+            "table",
+            "task",
+            "list",
+        ]
+
+    def test_trailing_format_equals_hoisted(self):
+        from clickup.cli.main import _hoist_global_format
+
+        assert _hoist_global_format(["task", "list", "--format=json"]) == ["--format=json", "task", "list"]
+
+    def test_leading_format_untouched(self):
+        from clickup.cli.main import _hoist_global_format
+
+        argv = ["--format", "json", "task", "list"]
+        assert _hoist_global_format(argv) == argv
+
+    def test_export_tasks_format_untouched(self):
+        from clickup.cli.main import _hoist_global_format
+
+        argv = ["bulk", "export-tasks", "--list-id", "1", "--format", "csv"]
+        assert _hoist_global_format(argv) == argv
+
+    def test_middle_flags_preserved(self):
+        from clickup.cli.main import _hoist_global_format
+
+        assert _hoist_global_format(["task", "list", "--list-id", "5", "--format", "table", "--brief"]) == [
+            "--format",
+            "table",
+            "task",
+            "list",
+            "--list-id",
+            "5",
+            "--brief",
+        ]
+
+    def test_no_format_untouched(self):
+        from clickup.cli.main import _hoist_global_format
+
+        argv = ["task", "list", "--brief"]
+        assert _hoist_global_format(argv) == argv

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-05T06:06:17.111362204Z"
+exclude-newer = "2026-06-05T06:15:29.015333481Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "clickup-toolkit"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- **`--format` accepted in any position**: `main()` hoists a trailing `--format <value>` to the root parser (`_hoist_global_format`). 7 of 18 eval agents instinctively appended it; the hint recovered them, but now the failed attempt never happens. `export-tasks` excluded (its `--format` alias means file format). AGENT.md decision 2 updated
- Root-help epilog now says `setup run --auto` (the agent-correct entry point)
- **Eval harness fix**: each of the 18 sub-agents gets its own `CLICKUP_CONFIG_PATH`. Sharing one file caused lost-update races between concurrent `save_config()` calls — run 3's "setup --auto doesn't persist" was this, not a CLI bug
- Records run 3: **18/18 pass** (`evals/afe5e5f-r3.json`), the first perfect run
- Version → 0.4.4

## Test plan

- [x] `just fc` green (671 passed, coverage 90.2%)
- [x] New hoist unit tests (pair/equals forms, leading untouched, export-tasks excluded, middle position); end-to-end `version --format table` smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)