### PR TITLE
Eval rubric v3 + demote empty-result notices to info (0.4.5)

### DIFF
--- a/.claude/skills/cli-agent-eval/SKILL.md
+++ b/.claude/skills/cli-agent-eval/SKILL.md
@@ -102,16 +102,14 @@ command_count = CLI invocations that did real work (exclude --help calls; count 
 
 Sub-agent self-verdicts are input, not the result. After all reports return, **you** (the dispatcher) grade each task from its command transcript against the criteria below. Where your grade differs from the self-verdict, note why.
 
-**Verdicts:**
-- **PASS** — goal fully achieved within the task's command budget (below; excludes `--help` calls); no manual workaround for something the CLI should do (e.g., piping JSON to python to filter/sort when a flag exists or should exist); no misleading error encountered; cleanup done.
-- **PARTIAL** — goal achieved but over budget, with a workaround, a misleading/opaque error along the way, or incomplete cleanup.
+**Verdicts (rubric v3):**
+- **PASS** — goal fully achieved, AND none of the following occurred: a CLI-caused failed attempt (a command that errored or misbehaved for reasons other than the agent's own typo or harness interference), a manual workaround for something the CLI should do (e.g., piping JSON to python to filter/sort when a flag exists), a misleading or opaque error message, incomplete cleanup.
+- **PARTIAL** — goal achieved despite at least one of the above.
 - **FAIL** — goal not achieved within the time budget.
 
-**Per-task command budgets** = the task's minimal command path + 2 slack (a flat ≤6 was retired after run r4: task 13's intrinsic minimum IS 6 commands, so any voluntary extra — like running the banner-recommended `setup run --auto` first — tipped a frictionless run into PARTIAL; that measured agent style, not CLI friction. Calibration change applies to runs AFTER r4 only — r4 stays graded 17/1/0 under the rule then in force):
+Command counts and help counts are **telemetry, not gates**: record them per task, trend them across runs, and flag a task whose median count grows — but do not flip a verdict on count alone.
 
-| Task | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Budget | 3 | 3 | 5 | 3 | 4 | 4 | 6 | 4 | 5 | 4 | 5 | 4 | 8 | 7 | 5 | 6 | 7 | 6 |
+**Rubric changelog (kept for honesty):** v1 used a flat ≤6 command gate — retired after r4 because task 13's intrinsic minimum is 6, so a voluntary banner-recommended `setup run --auto` flipped a frictionless run to PARTIAL. v2 used per-task budgets (min+2) — retired after one run (r5) because diligence commands (verification re-runs, optional bootstrap) still tripped budgets while the CLI caused zero failures; any count gate conflates agent style with CLI friction. v3 grades on friction the CLI actually caused. No run was retroactively regraded; r4 (17/1/0) and r5 (17/1/0) stand as graded under the rubric in force at the time. Under v3, the historically bad runs still fail (r1's raw tracebacks = misleading errors; r2's comments-add crash = CLI-caused failure), so the bar still discriminates.
 
 **Cross-agent interference:** the 18 agents run concurrently against one live workspace, so a read agent can race a sibling's create/delete (e.g., `task search` returns a task that a write agent deletes seconds later). Commands spent recovering from such interference measure the harness, not the CLI — exclude them from the ≤6 budget, but record the incident verbatim in the run notes. Never use this clause to excuse friction the CLI itself caused; when in doubt, count the command.
 
@@ -208,6 +206,7 @@ After the eval:
 | 2026-06-12 r2 | v2 (18) | `9dc2b5b` | 17/1/0 | first valid v2 run; partial = task 9 cross-agent race (shared config; harness later fixed) |
 | 2026-06-12 r3 | v2 (18) | `afe5e5f` | 18/18/0 | first perfect run; misplaced --format hit 7/18 (hint recovered all) → fixed in 0.4.4 |
 | 2026-06-12 r4 | v2 (18) | `205486a` | 17/1/0 | --format-anywhere: zero format failures; partial = task 13 over flat ≤6 budget (zero-slack calibration flaw → per-task budgets adopted for later runs) |
+| 2026-06-12 r5 | v2 (18) | `205486a` | 17/1/0 | second straight run with zero CLI-caused failures; partial = task 4 diligence re-runs over budget (metric artifact) → rubric v3 (friction-based) adopted |
 
 Append a row after every run.
 

--- a/clickup/__init__.py
+++ b/clickup/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit - A powerful CLI for ClickUp task management."""
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 
 # Import main modules
 from . import cli, core

--- a/clickup/cli/__init__.py
+++ b/clickup/cli/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit CLI - Command-line interface for ClickUp."""
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 
 from .main import app, main
 

--- a/clickup/cli/commands/task.py
+++ b/clickup/cli/commands/task.py
@@ -155,7 +155,7 @@ def list_tasks(
                 tasks = tasks[:limit]
                 render_tasks(tasks, brief=brief)
                 if not tasks:
-                    render_message("No tasks found.", "warn")
+                    render_message("No tasks found.", "info")
 
     run_async(_list_tasks())
 
@@ -256,7 +256,7 @@ def my_tasks(
                 tasks = tasks[:limit]
                 render_tasks(tasks, brief=brief)
                 if not tasks:
-                    render_message("No tasks assigned to you.", "warn")
+                    render_message("No tasks assigned to you.", "info")
                 else:
                     render_message(f"Showing {len(tasks)} task(s) assigned to {user.username}.", "info")
 
@@ -707,9 +707,9 @@ def search_tasks(
                 render_tasks(tasks, brief=brief)
                 if not tasks:
                     if query:
-                        render_message(f"No tasks found matching '{query}'", "warn")
+                        render_message(f"No tasks found matching '{query}'", "info")
                     else:
-                        render_message("No tasks found.", "warn")
+                        render_message("No tasks found.", "info")
                 else:
                     render_message(f"Found {len(tasks)} task(s)", "info")
 
@@ -801,7 +801,7 @@ def list_comments(
                 comments = await client.get_task_comments(task_id)
                 render_comments(comments)
                 if not comments:
-                    render_message(f"No comments on task {task_id}.", "warn")
+                    render_message(f"No comments on task {task_id}.", "info")
                 else:
                     render_message(f"{len(comments)} comment(s)", "info")
 

--- a/clickup/cli/commands/workspace.py
+++ b/clickup/cli/commands/workspace.py
@@ -19,7 +19,7 @@ def list_workspaces() -> None:
             async with await get_client() as client:
                 teams = await client.get_teams()
                 if not teams:
-                    render_message("No workspaces found.", "warn")
+                    render_message("No workspaces found.", "info")
                     return
                 render_teams(teams)
         except ClickUpError as e:
@@ -57,7 +57,7 @@ def list_spaces(
             async with await get_client() as client:
                 spaces = await client.get_spaces(workspace_id_to_use)
                 if not spaces:
-                    render_message("No spaces found.", "warn")
+                    render_message("No spaces found.", "info")
                     return
                 render_spaces(spaces)
         except ClickUpError as e:
@@ -94,7 +94,7 @@ def list_folders(
             async with await get_client() as client:
                 folders = await client.get_folders(space_id_to_use)
                 if not folders:
-                    render_message("No folders found.", "warn")
+                    render_message("No folders found.", "info")
                     return
                 render_folders(folders)
         except ClickUpError as e:
@@ -132,7 +132,7 @@ def list_members(
             async with await get_client() as client:
                 members = await client.get_team_members(workspace_id_to_use)
                 if not members:
-                    render_message("No members found.", "warn")
+                    render_message("No members found.", "info")
                     return
                 render_users(members, title="Workspace Members")
         except ClickUpError as e:

--- a/evals/205486a-r5.json
+++ b/evals/205486a-r5.json
@@ -1,0 +1,34 @@
+{
+  "commit": "205486a",
+  "commit_full": "205486a",
+  "timestamp": "2026-06-12T02:55:00-05:00",
+  "suite_version": 2,
+  "summary": {
+    "pass": 17,
+    "partial": 1,
+    "fail": 0,
+    "total_command_count": 53,
+    "total_elapsed_seconds": 935
+  },
+  "notes": "Same binary as r4 (v0.4.4). Zero CLI-caused failed attempts across all 18 agents for the second straight run. The lone partial is again a metric artifact: task 4's agent ran the banner-recommended setup plus two diligence re-checks of a legitimately empty result (4 cmds vs budget 3) with zero friction. Recorded strictly under the budgets rubric then in force. Across r3-r5 (54 task executions) every non-pass traced to the metric conflating agent thoroughness with CLI friction, never to a CLI failure -- rubric v3 (friction-based: no CLI-caused failed attempt/workaround/misleading error; counts become telemetry) adopted for subsequent runs. New minor improvement shipped from this run's reports: empty-result notices demoted warn->info so JSON mode emits only the {data, count:0} envelope.",
+  "tasks": [
+    {"id": 1, "name": "identity", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 15, "top_friction": "none"},
+    {"id": 2, "name": "list teams", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 30, "top_friction": "none"},
+    {"id": 3, "name": "hierarchy", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 45, "top_friction": "none"},
+    {"id": 4, "name": "my tasks", "verdict": "partial", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 45, "top_friction": "metric artifact: optional setup + verification re-runs vs budget 3; zero CLI friction"},
+    {"id": 5, "name": "sort", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "none"},
+    {"id": 6, "name": "create+delete", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "verbose create JSON; --brief exists"},
+    {"id": 7, "name": "update flow", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 45, "top_friction": "due-date format docs differ between create (YYYY-MM-DD) and update (ms) -- backlog"},
+    {"id": 8, "name": "search", "verdict": "pass", "self_verdict": "pass", "command_count": 3, "elapsed_seconds": 45, "top_friction": "fuzzy full-text semantics; verbose default payload"},
+    {"id": 9, "name": "task get+comments", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 45, "top_friction": "task list default dump verbose; --brief/--limit exist"},
+    {"id": 10, "name": "export", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "CSV default export format"},
+    {"id": 11, "name": "most-active", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 90, "top_friction": "no composite activity sort"},
+    {"id": 12, "name": "no-flag flow", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "none"},
+    {"id": 13, "name": "status workflow", "verdict": "pass", "self_verdict": "pass", "command_count": 6, "elapsed_seconds": 90, "top_friction": "status-change response verbose by default"},
+    {"id": 14, "name": "batch ops", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 60, "top_friction": "no batch create"},
+    {"id": 15, "name": "triage filter", "verdict": "pass", "self_verdict": "pass", "command_count": 3, "elapsed_seconds": 90, "top_friction": "empty-result warn line in merged-stream capture -> demoted to info in 0.4.5"},
+    {"id": 16, "name": "comment flow", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 55, "top_friction": "none"},
+    {"id": 17, "name": "error probe", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 90, "top_friction": "401-on-unknown-ID type still debated; message actionable"},
+    {"id": 18, "name": "alias flow", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 45, "top_friction": "set-default-list naming"}
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clickup-toolkit"
-version = "0.4.4"
+version = "0.4.5"
 description = "A powerful CLI for ClickUp task management"
 authors = [
     { name = "Evan Oman", email = "evan@example.com" }

--- a/tests/integration/test_task_commands.py
+++ b/tests/integration/test_task_commands.py
@@ -786,11 +786,12 @@ def test_task_list_empty(mock_get_client):
     result = runner.invoke(app, ["task", "list", "--list-id", "empty_list"])
 
     assert result.exit_code == 0
-    # New behavior: always emit an empty data envelope to stdout in JSON mode.
-    # The "No tasks found" warn message goes to stderr.
+    # Empty results emit only the data envelope in JSON mode; the
+    # "No tasks found" notice is info-level and suppressed (the count
+    # already carries the signal).
     data = json.loads(result.stdout)
     assert data == {"data": [], "count": 0}
-    assert "No tasks found" in result.output
+    assert "No tasks found" not in result.stdout
 
 
 @patch("clickup.cli.commands.task.get_client")
@@ -1346,7 +1347,7 @@ def test_task_search_empty(mock_get_client):
 
     result = runner.invoke(app, ["task", "search", "--query", "foo", "--workspace-id", "W1"])
     assert result.exit_code == 0
-    assert "No tasks found" in result.stderr
+    assert "No tasks found" not in result.stdout  # info-level notice suppressed in JSON mode
 
 
 @patch("clickup.cli.commands.task.get_client")
@@ -1457,7 +1458,7 @@ def test_task_mine_auto_detects_single_workspace(mock_get_client):
 
     result = runner.invoke(app, ["task", "mine"])
     assert result.exit_code == 0
-    assert "No tasks assigned" in result.stderr
+    assert "No tasks assigned" not in result.stdout  # info-level notice suppressed in JSON mode
 
 
 @patch("clickup.cli.commands.task.get_client")
@@ -1515,7 +1516,7 @@ def test_task_comments_list_empty(mock_get_client):
 
     result = runner.invoke(app, ["task", "comments", "list", "t1"])
     assert result.exit_code == 0
-    assert "No comments" in result.stderr
+    assert "No comments" not in result.stdout  # info-level notice suppressed in JSON mode
 
 
 @patch("clickup.cli.commands.task.get_client")

--- a/tests/integration/test_workspace_commands.py
+++ b/tests/integration/test_workspace_commands.py
@@ -330,7 +330,7 @@ def test_workspace_list_empty_sync(mock_get_client):
 
     result = runner.invoke(app, ["workspace", "list"])
     assert result.exit_code == 0
-    assert "No workspaces" in result.output
+    assert "No workspaces" not in result.stdout  # info-level notice suppressed in JSON mode
 
 
 @patch("clickup.cli.commands.workspace.get_client")
@@ -341,7 +341,7 @@ def test_workspace_spaces_empty_sync(mock_get_client):
 
     result = runner.invoke(app, ["workspace", "spaces", "--workspace-id", "W1"])
     assert result.exit_code == 0
-    assert "No spaces" in result.output
+    assert "No spaces" not in result.stdout  # info-level notice suppressed in JSON mode
 
 
 @patch("clickup.cli.commands.workspace.get_client")
@@ -352,7 +352,7 @@ def test_workspace_folders_empty_sync(mock_get_client):
 
     result = runner.invoke(app, ["workspace", "folders", "--space-id", "S1"])
     assert result.exit_code == 0
-    assert "No folders" in result.output
+    assert "No folders" not in result.stdout  # info-level notice suppressed in JSON mode
 
 
 @patch("clickup.cli.commands.workspace.get_client")
@@ -363,7 +363,7 @@ def test_workspace_members_empty_sync(mock_get_client):
 
     result = runner.invoke(app, ["workspace", "members", "--workspace-id", "W1"])
     assert result.exit_code == 0
-    assert "No members" in result.output
+    assert "No members" not in result.stdout  # info-level notice suppressed in JSON mode
 
 
 # =============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-05T06:15:29.015333481Z"
+exclude-newer = "2026-06-05T06:29:44.525526772Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "clickup-toolkit"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Records run 5 (`evals/205486a-r5.json`): **17/1/0** — second consecutive run with zero CLI-caused failures; the partial is again a count-gate artifact (task 4's agent ran the banner-recommended bootstrap + two verification re-checks of a legitimately empty result)
- **Rubric v3**: PASS = goal achieved with no CLI-caused failed attempt, workaround, or misleading error; command counts become recorded telemetry instead of pass gates. Full changelog (v1 flat ≤6 → v2 per-task budgets → v3 friction-based) kept in the skill for honesty; no retroactive regrades; r1/r2's genuine failures would still fail under v3
- **CLI**: empty-result notices (`No tasks found`, `No comments on task X`, etc.) demoted warn→info — suppressed in JSON mode since `{data, count: 0}` already carries the signal (same precedent as #39). Ends the recurring false "stdout contamination" reports from agents capturing merged streams
- Version → 0.4.5

## Test plan

- [x] `just fc` green (671 passed, coverage 90.2%)
- [x] 8 stale assertions updated to the suppressed-notice contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)