### PR TITLE
Eval runs r6 + r7: two consecutive 18/18 (consistency goal met)

### DIFF
--- a/.claude/skills/cli-agent-eval/SKILL.md
+++ b/.claude/skills/cli-agent-eval/SKILL.md
@@ -207,6 +207,8 @@ After the eval:
 | 2026-06-12 r3 | v2 (18) | `afe5e5f` | 18/18/0 | first perfect run; misplaced --format hit 7/18 (hint recovered all) → fixed in 0.4.4 |
 | 2026-06-12 r4 | v2 (18) | `205486a` | 17/1/0 | --format-anywhere: zero format failures; partial = task 13 over flat ≤6 budget (zero-slack calibration flaw → per-task budgets adopted for later runs) |
 | 2026-06-12 r5 | v2 (18) | `205486a` | 17/1/0 | second straight run with zero CLI-caused failures; partial = task 4 diligence re-runs over budget (metric artifact) → rubric v3 (friction-based) adopted |
+| 2026-06-12 r6 | v2 (18), rubric v3 | `fd8b775` | **18/18/0** | zero CLI-caused failures; precedent: delete safety-gate refusal is the documented contract, not a failure |
+| 2026-06-12 r7 | v2 (18), rubric v3 | `fd8b775` | **18/18/0** | second consecutive clean run on the same binary — consistency goal met; remaining ideas appended to issue #49 |
 
 Append a row after every run.
 

--- a/evals/fd8b775-r6.json
+++ b/evals/fd8b775-r6.json
@@ -1,0 +1,35 @@
+{
+  "commit": "fd8b775",
+  "commit_full": "fd8b775",
+  "timestamp": "2026-06-12T03:25:00-05:00",
+  "suite_version": 2,
+  "rubric_version": 3,
+  "summary": {
+    "pass": 18,
+    "partial": 0,
+    "fail": 0,
+    "total_command_count": 58,
+    "total_elapsed_seconds": 1085
+  },
+  "notes": "First run under rubric v3 (v0.4.5 binary). Zero CLI-caused failed attempts, workarounds, or misleading errors across all 18 agents. Grading precedent recorded: the delete safety gate refusing without --force (task 16) is the documented contract operating as designed with a self-explanatory message ('the error message made recovery trivial') and does not count as a CLI-caused failure; task 17 probes this same refusal as exemplary behavior. Recurring backlog (non-blocking): batch create (3x across runs), composite list-stats activity sort, zero-result '0 matched (N total)' summary, search --name-only, ResourceAccessError vs NotFoundError type debate, export JSON default.",
+  "tasks": [
+    {"id": 1, "name": "identity", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 15, "top_friction": "none"},
+    {"id": 2, "name": "list teams", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 30, "top_friction": "none"},
+    {"id": 3, "name": "hierarchy", "verdict": "pass", "self_verdict": "pass", "command_count": 3, "elapsed_seconds": 45, "top_friction": "none; guessed --format position from help"},
+    {"id": 4, "name": "my tasks", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 45, "top_friction": "zero-result hint idea"},
+    {"id": 5, "name": "sort", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "none; praised --sort help text"},
+    {"id": 6, "name": "create+delete", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "verbose create JSON; --brief exists"},
+    {"id": 7, "name": "update flow", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 55, "top_friction": "none; --fields projection idea"},
+    {"id": 8, "name": "search", "verdict": "pass", "self_verdict": "pass", "command_count": 3, "elapsed_seconds": 45, "top_friction": "fuzzy full-text semantics (documented); --name-only idea"},
+    {"id": 9, "name": "task get+comments", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 90, "top_friction": "none; --include-comments idea"},
+    {"id": 10, "name": "export", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 60, "top_friction": "CSV default; --format namespace overlap"},
+    {"id": 11, "name": "most-active", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 90, "top_friction": "no composite activity sort"},
+    {"id": 12, "name": "no-flag flow", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 60, "top_friction": "suggest --brief in quickstart"},
+    {"id": 13, "name": "status workflow", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 90, "top_friction": "task list verbosity claim (--brief exists, agent missed it)"},
+    {"id": 14, "name": "batch ops", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 90, "top_friction": "no batch create"},
+    {"id": 15, "name": "triage filter", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 120, "top_friction": "zero-result ambiguity cost verification commands; '0 matched (N total)' idea"},
+    {"id": 16, "name": "comment flow", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 60, "top_friction": "delete safety gate refusal (by design; recovery instant)"},
+    {"id": 17, "name": "error probe", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 90, "top_friction": "ResourceAccessError vs NotFoundError type debate; message judged actionable"},
+    {"id": 18, "name": "alias flow", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 60, "top_friction": "none"}
+  ]
+}

--- a/evals/fd8b775-r7.json
+++ b/evals/fd8b775-r7.json
@@ -1,0 +1,35 @@
+{
+  "commit": "fd8b775",
+  "commit_full": "fd8b775",
+  "timestamp": "2026-06-12T03:55:00-05:00",
+  "suite_version": 2,
+  "rubric_version": 3,
+  "summary": {
+    "pass": 18,
+    "partial": 0,
+    "fail": 0,
+    "total_command_count": 53,
+    "total_elapsed_seconds": 955
+  },
+  "notes": "Second consecutive 18/18 run on the same v0.4.5 binary under rubric v3 -- goal condition met (consistent passes). Zero CLI-caused failed attempts, workarounds, or misleading errors across all 18 agents; multiple agents explicitly reported 'zero failed attempts'. Notable: task 3 built the full hierarchy in ONE working command. Remaining non-blocking backlog (appended to issue #49): batch task create (variadic names), list stats --sort activity composite, zero-result '0 matched (N total)' hint, search --name-only filter, ResourceAccessError message should lead with the unknown-ID possibility rather than invalid-token, export-tasks JSON default, list stats mention in quickstart.",
+  "tasks": [
+    {"id": 1, "name": "identity", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 25, "top_friction": "none"},
+    {"id": 2, "name": "list teams", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 30, "top_friction": "none"},
+    {"id": 3, "name": "hierarchy", "verdict": "pass", "self_verdict": "pass", "command_count": 1, "elapsed_seconds": 45, "top_friction": "none; full tree in one command"},
+    {"id": 4, "name": "my tasks", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "README/help wording nuance on task mine scope"},
+    {"id": 5, "name": "sort", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "none"},
+    {"id": 6, "name": "create+delete", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "verbose create JSON; --brief exists"},
+    {"id": 7, "name": "update flow", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 45, "top_friction": "none; changes-diff idea"},
+    {"id": 8, "name": "search", "verdict": "pass", "self_verdict": "pass", "command_count": 3, "elapsed_seconds": 45, "top_friction": "verbose default; --brief found via help; --name-only idea"},
+    {"id": 9, "name": "task get+comments", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 45, "top_friction": "task list verbosity claim (--brief exists, agent missed it)"},
+    {"id": 10, "name": "export", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "CSV default export format"},
+    {"id": 11, "name": "most-active", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 60, "top_friction": "list stats not hinted at top-level help"},
+    {"id": 12, "name": "no-flag flow", "verdict": "pass", "self_verdict": "pass", "command_count": 2, "elapsed_seconds": 45, "top_friction": "auto-setup notice visible in merged-stream capture (stderr)"},
+    {"id": 13, "name": "status workflow", "verdict": "pass", "self_verdict": "pass", "command_count": 6, "elapsed_seconds": 90, "top_friction": "task list --brief missed again (discoverability nuance, no failure)"},
+    {"id": 14, "name": "batch ops", "verdict": "pass", "self_verdict": "pass", "command_count": 5, "elapsed_seconds": 60, "top_friction": "no batch create; zero failed attempts"},
+    {"id": 15, "name": "triage filter", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 90, "top_friction": "zero-result hint idea"},
+    {"id": 16, "name": "comment flow", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 65, "top_friction": "none"},
+    {"id": 17, "name": "error probe", "verdict": "pass", "self_verdict": "pass", "command_count": 6, "elapsed_seconds": 90, "top_friction": "ResourceAccessError message should lead with unknown-ID possibility"},
+    {"id": 18, "name": "alias flow", "verdict": "pass", "self_verdict": "pass", "command_count": 4, "elapsed_seconds": 45, "top_friction": "none"}
+  ]
+}


### PR DESCRIPTION
## Summary

- Records runs 6 and 7 (`evals/fd8b775-r6.json`, `-r7.json`): **both 18/18** on the same v0.4.5 binary under rubric v3 — zero CLI-caused failures across 36 task executions; several agents explicitly reported "zero failed attempts"
- Result-history table updated; remaining non-blocking polish ideas appended to #49 (batch create, error-message framing, zero-result hints, etc.)

## Test plan

- [x] Eval bookkeeping only; no production code
- [x] Workspace verified clean (no leftover `agent-test-eval-*` tasks); eval temp dirs removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)