### PR TITLE
Backlog batch 1: batch create, clearer 401s, zero-result hints, --name-only (0.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup status
 # 3. Discover list IDs in your workspace
 uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup discover hierarchy
 
-# 4. List tasks in your default list
-uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup task list
+# 4. Orient: per-list task counts and last-updated times
+uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup list stats
+
+# 5. List tasks in your default list (--brief = compact projection, recommended for agents)
+uvx --from git+https://github.com/EvanOman/clickup-tools.git clickup task list --brief
 ```
 
 For repeat use, install once and then call `clickup` directly:

--- a/clickup/__init__.py
+++ b/clickup/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit - A powerful CLI for ClickUp task management."""
 
-__version__ = "0.4.5"
+__version__ = "0.5.0"
 
 # Import main modules
 from . import cli, core

--- a/clickup/cli/__init__.py
+++ b/clickup/cli/__init__.py
@@ -1,6 +1,6 @@
 """ClickUp Toolkit CLI - Command-line interface for ClickUp."""
 
-__version__ = "0.4.5"
+__version__ = "0.5.0"
 
 from .main import app, main
 

--- a/clickup/cli/commands/task.py
+++ b/clickup/cli/commands/task.py
@@ -146,6 +146,20 @@ def list_tasks(
                     tasks.extend(list_tasks_result)
                 # Client-side filter + sort pipeline. open_only and sort are
                 # applied here (status/date filters already went to the API).
+                pre_filter_count = len(tasks)
+                has_filters = any(
+                    [
+                        status,
+                        assignee,
+                        open_only,
+                        created_since,
+                        created_after,
+                        created_before,
+                        updated_since,
+                        updated_after,
+                        updated_before,
+                    ]
+                )
                 tasks = apply_task_filters(
                     tasks,
                     open_only=open_only,
@@ -155,7 +169,13 @@ def list_tasks(
                 tasks = tasks[:limit]
                 render_tasks(tasks, brief=brief)
                 if not tasks:
-                    render_message("No tasks found.", "info")
+                    if has_filters:
+                        render_message(
+                            f"0 tasks matched the active filters (list has {pre_filter_count} tasks total).",
+                            "info",
+                        )
+                    else:
+                        render_message("No tasks found.", "info")
 
     run_async(_list_tasks())
 
@@ -245,6 +265,8 @@ def my_tasks(
                 )
 
                 # Client-side filter + sort via shared pipeline.
+                pre_filter_count = len(tasks)
+                has_filters = any([status_filter, updated_since_ms, open_only])
                 tasks = apply_task_filters(
                     tasks,
                     statuses=status_filter,
@@ -256,7 +278,13 @@ def my_tasks(
                 tasks = tasks[:limit]
                 render_tasks(tasks, brief=brief)
                 if not tasks:
-                    render_message("No tasks assigned to you.", "info")
+                    if has_filters:
+                        render_message(
+                            f"0 tasks matched the active filters ({pre_filter_count} tasks total).",
+                            "info",
+                        )
+                    else:
+                        render_message("No tasks assigned to you.", "info")
                 else:
                     render_message(f"Showing {len(tasks)} task(s) assigned to {user.username}.", "info")
 
@@ -265,7 +293,7 @@ def my_tasks(
 
 @app.command("create")
 def create_task(
-    name: str = typer.Argument(..., help="Task name"),
+    names: list[str] = typer.Argument(..., metavar="NAME...", help="One or more task names"),
     list_id: str | None = typer.Option(None, "--list-id", "-l", help="List ID or alias to create task in"),
     description: str | None = typer.Option(None, "--description", "-d", help="Task description"),
     priority: int | None = typer.Option(
@@ -275,7 +303,9 @@ def create_task(
         help="Priority (1=urgent, 2=high, 3=normal, 4=low).",
     ),
     assignee: str | None = typer.Option(None, "--assignee", "-a", help="Assignee user ID"),
-    due_date: str | None = typer.Option(None, "--due-date", help="Due date (YYYY-MM-DD)"),
+    due_date: str | None = typer.Option(
+        None, "--due-date", help="Due date (YYYY-MM-DD, ISO datetime, epoch ms, or relative like 7d)"
+    ),
     status: str | None = typer.Option(
         None,
         "--status",
@@ -284,8 +314,14 @@ def create_task(
     ),
     brief: bool = typer.Option(False, "--brief", help="Return a stripped projection (see `task get --brief`)."),
 ) -> None:
-    """Create a new task."""
-    validate_task_name(name)
+    """Create one or more tasks.
+
+    Pass multiple names to create several tasks at once — all flags
+    (--description, --priority, --status, etc.) apply to every task.
+    Single-name invocations are byte-identical to the old behavior.
+    """
+    for task_name in names:
+        validate_task_name(task_name)
     validate_priority(priority)
 
     async def _create_task() -> None:
@@ -295,7 +331,7 @@ def create_task(
         status_to_use = status or config.get("default_status")
 
         with handle_clickup_errors():
-            task_data: dict[str, Any] = {"name": name}
+            task_data: dict[str, Any] = {}
 
             if description is not None:
                 task_data["description"] = description
@@ -304,18 +340,44 @@ def create_task(
             if assignee is not None:
                 task_data["assignees"] = [assignee]
             if due_date is not None:
-                task_data["due_date"] = due_date
+                task_data["due_date"] = str(epoch_ms(due_date))
             if status_to_use:
                 task_data["status"] = status_to_use
 
             async with await get_client() as client:
-                task = await client.create_task(list_id_to_use, **task_data)
-                if get_format() == "json":
-                    render_task(task, brief=brief)
+                if len(names) == 1:
+                    # Single task — byte-identical to old behavior.
+                    task = await client.create_task(list_id_to_use, name=names[0], **task_data)
+                    if get_format() == "json":
+                        render_task(task, brief=brief)
+                        return
+                    render_message(f"Created task: {task.name} (ID: {task.id})", "success")
+                    if task.url:
+                        render_message(f"URL: {task.url}", "info")
                     return
-                render_message(f"Created task: {task.name} (ID: {task.id})", "success")
-                if task.url:
-                    render_message(f"URL: {task.url}", "info")
+
+                # Batch create — concurrent with partial-failure semantics.
+                results = await gather_bounded(
+                    [client.create_task(list_id_to_use, name=n, **task_data) for n in names],
+                    limit=5,
+                )
+                succeeded: list[Any] = []
+                failures: list[tuple[str, BaseException]] = []
+                for task_name, result in zip(names, results, strict=False):
+                    if isinstance(result, BaseException):
+                        failures.append((task_name, result))
+                    else:
+                        succeeded.append(result)
+
+                # Render successes preserving input order.
+                ordered = [r for r in results if not isinstance(r, BaseException)]
+                render_tasks(ordered, brief=brief)
+
+                for task_name, exc in failures:
+                    render_error(f"Failed to create task '{task_name}': {exc}", error_type=type(exc).__name__)
+
+                if failures:
+                    raise typer.Exit(1)
 
     run_async(_create_task())
 
@@ -341,7 +403,9 @@ def update_task(
         "-p",
         help="New priority (1=urgent, 2=high, 3=normal, 4=low).",
     ),
-    due_date: str | None = typer.Option(None, "--due-date", help="New due date (ms timestamp)"),
+    due_date: str | None = typer.Option(
+        None, "--due-date", help="New due date (YYYY-MM-DD, ISO datetime, epoch ms, or relative like 7d)"
+    ),
     archived: bool | None = typer.Option(None, "--archived/--unarchived", help="Archive state"),
     brief: bool = typer.Option(False, "--brief", help="Return a stripped projection (see `task get --brief`)."),
 ) -> None:
@@ -370,7 +434,7 @@ def update_task(
         if priority is not None:
             updates["priority"] = priority
         if due_date is not None:
-            updates["due_date"] = due_date
+            updates["due_date"] = str(epoch_ms(due_date))
         if archived is not None:
             updates["archived"] = archived
 
@@ -673,6 +737,14 @@ def search_tasks(
         help="Hide tasks whose status type is 'closed'.",
     ),
     limit: int = typer.Option(50, "--limit", help="Maximum number of tasks to show"),
+    name_only: bool = typer.Option(
+        False,
+        "--name-only",
+        help=(
+            "Keep only tasks whose NAME contains the query "
+            "(ClickUp's search is full-text across descriptions/comments)."
+        ),
+    ),
     brief: bool = typer.Option(False, "--brief", help="Return a stripped projection (see `task list --brief`)."),
 ) -> None:
     """Search for tasks across the workspace.
@@ -694,6 +766,8 @@ def search_tasks(
             async with await get_client() as client:
                 id_to_use = await resolve_workspace_id(client, workspace_id or team_id)
                 tasks = await client.search_tasks(id_to_use, query or "")
+                pre_filter_count = len(tasks)
+                has_filters = any([status_filter, updated_since_ms, open_only, query, name_only])
                 # Client-side filter + sort via shared pipeline.
                 tasks = apply_task_filters(
                     tasks,
@@ -703,10 +777,18 @@ def search_tasks(
                     sort_field=order_by,
                     sort_descending=descending,
                 )
+                if name_only and query:
+                    query_lower = query.lower()
+                    tasks = [t for t in tasks if query_lower in t.name.lower()]
                 tasks = tasks[:limit]
                 render_tasks(tasks, brief=brief)
                 if not tasks:
-                    if query:
+                    if has_filters:
+                        render_message(
+                            f"0 tasks matched the active filters ({pre_filter_count} tasks total).",
+                            "info",
+                        )
+                    elif query:
                         render_message(f"No tasks found matching '{query}'", "info")
                     else:
                         render_message("No tasks found.", "info")

--- a/clickup/core/client.py
+++ b/clickup/core/client.py
@@ -73,14 +73,20 @@ class ClickUpClient:
                 except (json.JSONDecodeError, ValueError):
                     error_data = {}
                 detail = error_data.get("err", "") if isinstance(error_data, dict) else ""
+                if self._RESOURCE_ENDPOINT_RE.search(endpoint):
+                    message = (
+                        f"ClickUp returned 401 for {endpoint}"
+                        f"{': ' + detail if detail else ''}. "
+                        "For resource endpoints this usually means the ID does not exist "
+                        "or is not accessible to this token; it can also mean the token "
+                        "itself is invalid — if other commands work, double-check the ID."
+                    )
+                    raise ResourceAccessError(message, response.status_code)
                 message = (
                     f"ClickUp rejected the request (401{': ' + detail if detail else ''}). "
-                    "This usually means an invalid API token, but ClickUp also returns 401 "
-                    "for resource IDs that don't exist or aren't accessible to this token. "
+                    "This usually means an invalid API token. "
                     "If other commands work, double-check the ID."
                 )
-                if self._RESOURCE_ENDPOINT_RE.search(endpoint):
-                    raise ResourceAccessError(message, response.status_code)
                 raise AuthenticationError(message, response.status_code)
             elif response.status_code == 403:
                 raise AuthorizationError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clickup-toolkit"
-version = "0.4.5"
+version = "0.5.0"
 description = "A powerful CLI for ClickUp task management"
 authors = [
     { name = "Evan Oman", email = "evan@example.com" }

--- a/tests/integration/test_backlog_49.py
+++ b/tests/integration/test_backlog_49.py
@@ -1,0 +1,493 @@
+"""Tests for backlog-49 batch 1 features.
+
+Covers:
+- Item 1: batch task create
+- Item 2: 401 message reword
+- Item 3: zero-result hints
+- Item 4: --name-only filter on task search
+- Item 5: due-date format consistency
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from clickup.cli.main import app
+from clickup.core.exceptions import ClickUpError
+from clickup.core.models import StatusInfo, Task, User
+
+from .conftest import make_mock_ctx
+
+runner = CliRunner()
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_task(id: str, name: str, **overrides) -> Task:
+    """Build a real Task model for tests that need model_dump."""
+    kwargs = {"id": id, "name": name}
+    kwargs.update(overrides)
+    return Task(**kwargs)
+
+
+# =============================================================================
+# Item 1 — batch task create
+# =============================================================================
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_batch_create_three_tasks_collection_envelope(mock_get_client):
+    """3 names -> 3 tasks in order, collection envelope, flags applied to all."""
+    mock_client = AsyncMock()
+    mock_client.create_task.side_effect = [
+        _make_task("t1", "Alpha", url="https://x/t1"),
+        _make_task("t2", "Bravo", url="https://x/t2"),
+        _make_task("t3", "Charlie", url="https://x/t3"),
+    ]
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        [
+            "task",
+            "create",
+            "Alpha",
+            "Bravo",
+            "Charlie",
+            "--list-id",
+            "L1",
+            "--description",
+            "shared desc",
+            "--priority",
+            "2",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["count"] == 3
+    assert [t["name"] for t in data["data"]] == ["Alpha", "Bravo", "Charlie"]
+
+    # Verify flags applied to every call
+    for call in mock_client.create_task.await_args_list:
+        assert call.kwargs["description"] == "shared desc"
+        assert call.kwargs["priority"] == 2
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_single_create_unchanged_shape(mock_get_client):
+    """Single name produces a singleton task object, NOT a collection envelope."""
+    mock_client = AsyncMock()
+    mock_client.create_task.return_value = _make_task("t1", "Solo", url="https://x/t1")
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(app, ["task", "create", "Solo", "--list-id", "L1"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["id"] == "t1"
+    assert data["name"] == "Solo"
+    # No "data" / "count" keys — singleton shape
+    assert "data" not in data
+    assert "count" not in data
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_batch_create_partial_failure_exit_1(mock_get_client):
+    """When some creates fail: successes rendered, failures warned, exit 1."""
+    mock_client = AsyncMock()
+    mock_client.create_task.side_effect = [
+        _make_task("t1", "Good"),
+        ClickUpError("rate limited"),
+        _make_task("t3", "Also Good"),
+    ]
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["task", "create", "Good", "Bad", "Also Good", "--list-id", "L1"],
+    )
+
+    assert result.exit_code == 1
+    data = json.loads(result.stdout)
+    # Only the 2 successes appear in the envelope
+    assert data["count"] == 2
+    assert [t["name"] for t in data["data"]] == ["Good", "Also Good"]
+    # Error on stderr
+    assert "Failed to create task 'Bad'" in result.stderr
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_batch_create_brief(mock_get_client):
+    """--brief works for batch creates."""
+    mock_client = AsyncMock()
+    mock_client.create_task.side_effect = [
+        _make_task("t1", "A", description="long text", url="https://x"),
+        _make_task("t2", "B", description="long text 2", url="https://x"),
+    ]
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["task", "create", "A", "B", "--list-id", "L1", "--brief"],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["count"] == 2
+    for t in data["data"]:
+        assert "description" not in t
+
+
+def test_batch_create_validates_each_name():
+    """Each name is validated — empty names rejected."""
+    result = runner.invoke(app, ["task", "create", "Good", "   ", "--list-id", "L1"])
+    assert result.exit_code == 2
+    assert "empty" in result.stderr.lower()
+
+
+# =============================================================================
+# Item 2 — 401 message wording
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_401_resource_endpoint_leads_with_id_interpretation(mock_clickup_client):
+    """Resource endpoint 401 now leads with 'the ID does not exist'."""
+    from clickup.core.exceptions import ResourceAccessError
+
+    mock_response = Mock()
+    mock_response.status_code = 401
+    mock_response.content = b'{"err": "Team not authorized"}'
+    mock_response.json.return_value = {"err": "Team not authorized"}
+
+    mock_clickup_client.client.request.return_value = mock_response
+
+    with pytest.raises(ResourceAccessError) as exc:
+        await mock_clickup_client._request("GET", "/task/doesnotexist123")
+    msg = str(exc.value)
+    # Message leads with the resource interpretation
+    assert msg.startswith("ClickUp returned 401 for /task/doesnotexist123")
+    assert "the ID does not exist" in msg
+    assert "token itself is invalid" in msg
+
+
+@pytest.mark.asyncio
+async def test_401_auth_endpoint_leads_with_invalid_token(mock_clickup_client):
+    """Auth endpoint (/user) 401 still leads with invalid token."""
+    from clickup.core.exceptions import AuthenticationError
+
+    mock_response = Mock()
+    mock_response.status_code = 401
+    mock_response.content = b'{"err": "Unauthorized"}'
+    mock_response.json.return_value = {"err": "Unauthorized"}
+
+    mock_clickup_client.client.request.return_value = mock_response
+
+    with pytest.raises(AuthenticationError) as exc:
+        await mock_clickup_client._request("GET", "/user")
+    msg = str(exc.value)
+    assert "invalid API token" in msg
+
+
+# =============================================================================
+# Item 3 — zero-result hints
+# =============================================================================
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_zero_result_hint_filtered_empty_table_mode(mock_get_client):
+    """Filtered-empty emits info message with pre-filter count in table mode.
+
+    Uses --open-only because it's a client-side filter in task list,
+    so pre_filter_count reflects the full API result. status filters go to
+    the API directly, so the pre-filter count wouldn't show a difference.
+    """
+    mock_client = AsyncMock()
+    # List has 5 tasks, all closed — open-only will filter them all out
+    tasks = [_make_task(f"t{i}", f"Task {i}", status=StatusInfo(status="complete", type="closed")) for i in range(5)]
+    mock_client.get_tasks.return_value = tasks
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["--format", "table", "task", "list", "--list-id", "L1", "--open-only"],
+    )
+
+    assert result.exit_code == 0
+    # The hint goes to stdout in table mode (via render_message info level -> Rich console on stdout)
+    combined = result.stdout + result.stderr
+    assert "0 tasks matched the active filters" in combined
+    assert "5 tasks total" in combined
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_zero_result_hint_json_mode_suppressed(mock_get_client):
+    """In JSON mode, info-level hint is suppressed; only envelope on stdout."""
+    mock_client = AsyncMock()
+    tasks = [_make_task(f"t{i}", f"Task {i}", status=StatusInfo(status="complete", type="closed")) for i in range(3)]
+    mock_client.get_tasks.return_value = tasks
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["task", "list", "--list-id", "L1", "--open-only"],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data == {"data": [], "count": 0}
+    # info-level message suppressed in JSON mode
+    assert "0 tasks matched" not in result.stdout
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_zero_result_no_hint_when_unfiltered(mock_get_client):
+    """Unfiltered empty list emits 'No tasks found' — no hint about filters."""
+    mock_client = AsyncMock()
+    mock_client.get_tasks.return_value = []
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["--format", "table", "task", "list", "--list-id", "L1"],
+    )
+
+    assert result.exit_code == 0
+    combined = result.stdout + result.stderr
+    assert "0 tasks matched the active filters" not in combined
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_zero_result_hint_task_search_with_filters(mock_get_client):
+    """task search emits zero-result hint when filters are active."""
+    mock_client = AsyncMock()
+    mock_client.search_tasks.return_value = [
+        _make_task("t1", "Alpha", status=StatusInfo(status="open")),
+    ]
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["--format", "table", "task", "search", "--query", "alpha", "--status", "closed", "--workspace-id", "W1"],
+    )
+
+    assert result.exit_code == 0
+    combined = result.stdout + result.stderr
+    assert "0 tasks matched the active filters" in combined
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_zero_result_hint_task_mine_with_filters(mock_get_client):
+    """task mine emits zero-result hint when filters are active."""
+    mock_client = AsyncMock()
+    mock_client.get_user.return_value = User(id=42, username="evan", email="e@x.com")
+    mock_client.search_tasks.return_value = [
+        _make_task("t1", "My Task", status=StatusInfo(status="open")),
+    ]
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["--format", "table", "task", "mine", "--workspace-id", "W1", "--open-only"],
+    )
+
+    # With open-only, 1 task matches (it's open), so no hint here.
+    # Let's test with a status that filters everything out.
+    mock_client.search_tasks.return_value = [
+        _make_task("t1", "My Task", status=StatusInfo(status="open")),
+    ]
+    result = runner.invoke(
+        app,
+        ["--format", "table", "task", "mine", "--workspace-id", "W1", "--status", "nonexistent"],
+    )
+
+    assert result.exit_code == 0
+    combined = result.stdout + result.stderr
+    assert "0 tasks matched the active filters" in combined
+
+
+# =============================================================================
+# Item 4 — task search --name-only
+# =============================================================================
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_name_only_filters_by_task_name(mock_get_client):
+    """--name-only keeps only tasks whose name contains the query (case-insensitive)."""
+    mock_client = AsyncMock()
+    mock_client.search_tasks.return_value = [
+        _make_task("t1", "Deploy API"),
+        _make_task("t2", "Write API docs"),
+        _make_task("t3", "Fix login bug"),  # 'api' only in description/comments
+    ]
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["task", "search", "--query", "api", "--workspace-id", "W1", "--name-only"],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["count"] == 2
+    names = [t["name"] for t in data["data"]]
+    assert "Deploy API" in names
+    assert "Write API docs" in names
+    assert "Fix login bug" not in names
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_name_only_case_insensitive(mock_get_client):
+    """--name-only matching is case-insensitive."""
+    mock_client = AsyncMock()
+    mock_client.search_tasks.return_value = [
+        _make_task("t1", "URGENT Bug Fix"),
+        _make_task("t2", "urgent refactor"),
+        _make_task("t3", "Normal task"),
+    ]
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["task", "search", "--query", "urgent", "--workspace-id", "W1", "--name-only"],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["count"] == 2
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_name_only_with_limit(mock_get_client):
+    """--name-only + --limit: count reflects the filtered (then truncated) set."""
+    mock_client = AsyncMock()
+    mock_client.search_tasks.return_value = [_make_task(f"t{i}", f"Matching {i}") for i in range(10)]
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["task", "search", "--query", "Matching", "--workspace-id", "W1", "--name-only", "--limit", "3"],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["count"] == 3
+
+
+# =============================================================================
+# Item 5 — due-date format consistency
+# =============================================================================
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_create_due_date_accepts_yyyy_mm_dd(mock_get_client):
+    """task create --due-date 2026-07-01 sends epoch ms to the provider."""
+    mock_client = AsyncMock()
+    mock_client.create_task.return_value = _make_task("t1", "X")
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["task", "create", "X", "--list-id", "L1", "--due-date", "2026-07-01"],
+    )
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.create_task.call_args.kwargs
+    due_val = call_kwargs["due_date"]
+    # Should be epoch-ms string for 2026-07-01 00:00:00 UTC
+    assert due_val == str(1782864000000)
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_create_due_date_accepts_relative(mock_get_client):
+    """task create --due-date 7d sends an epoch-ms in the recent past."""
+    mock_client = AsyncMock()
+    mock_client.create_task.return_value = _make_task("t1", "X")
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["task", "create", "X", "--list-id", "L1", "--due-date", "7d"],
+    )
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.create_task.call_args.kwargs
+    due_val = int(call_kwargs["due_date"])
+    # Should be a valid epoch-ms (roughly now - 7 days)
+    assert due_val > 0
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_update_due_date_accepts_yyyy_mm_dd(mock_get_client):
+    """task update --due-date 2026-07-01 sends epoch ms to the provider."""
+    mock_client = AsyncMock()
+    mock_client.update_task.return_value = _make_task("t1", "X")
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["task", "update", "t1", "--due-date", "2026-07-01"],
+    )
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.update_task.call_args.kwargs
+    due_val = call_kwargs["due_date"]
+    assert due_val == str(1782864000000)
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_update_due_date_accepts_relative(mock_get_client):
+    """task update --due-date 7d sends epoch ms."""
+    mock_client = AsyncMock()
+    mock_client.update_task.return_value = _make_task("t1", "X")
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["task", "update", "t1", "--due-date", "7d"],
+    )
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.update_task.call_args.kwargs
+    due_val = int(call_kwargs["due_date"])
+    assert due_val > 0
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_update_due_date_accepts_epoch_ms(mock_get_client):
+    """task update --due-date <epoch-ms> passes through unchanged."""
+    mock_client = AsyncMock()
+    mock_client.update_task.return_value = _make_task("t1", "X")
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["task", "update", "t1", "--due-date", "1782691200000"],
+    )
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.update_task.call_args.kwargs
+    assert call_kwargs["due_date"] == "1782691200000"
+
+
+@patch("clickup.cli.commands.task.get_client")
+def test_create_due_date_accepts_epoch_ms(mock_get_client):
+    """task create --due-date <epoch-ms> passes through unchanged."""
+    mock_client = AsyncMock()
+    mock_client.create_task.return_value = _make_task("t1", "X")
+    mock_get_client.return_value = make_mock_ctx(mock_client)
+
+    result = runner.invoke(
+        app,
+        ["task", "create", "X", "--list-id", "L1", "--due-date", "1782691200000"],
+    )
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.create_task.call_args.kwargs
+    assert call_kwargs["due_date"] == "1782691200000"

--- a/tests/unit/test_core_client.py
+++ b/tests/unit/test_core_client.py
@@ -346,7 +346,8 @@ async def test_401_on_resource_endpoint_raises_resource_access_error(mock_clicku
         await mock_clickup_client._request("GET", "/task/doesnotexist123")
     msg = str(exc.value)
     assert "Team not authorized" in msg
-    assert "resource IDs" in msg
+    assert "401 for /task/doesnotexist123" in msg
+    assert "the ID does not exist" in msg
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-05T06:29:44.525526772Z"
+exclude-newer = "2026-06-05T06:47:29.850327027Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "clickup-toolkit"
-version = "0.4.5"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Implements the five most-requested items from issue #49's eval-driven backlog:

- **`task create "a" "b" "c" --list-id X`** — variadic names mirroring `done`/`delete`: concurrent creation (`gather_bounded`), input-order collection envelope, per-failure stderr + exit 1; single-name output byte-identical (back-compat)
- **401 framing**: resource endpoints lead with "the ID does not exist or is not accessible" (3 eval agents reported the old invalid-token-first wording sent them down the wrong diagnostic path); auth-root endpoints unchanged
- **Zero-result hints**: filtered-empty `task list/mine/search` say "0 tasks matched the active filters (list has N total)" in table mode — suppressed in JSON where `count: 0` already carries it; no added API calls
- **`task search --name-only`** — client-side case-insensitive name filter over ClickUp's full-text matches
- **Due-date consistency**: create and update both accept YYYY-MM-DD / ISO / epoch-ms / relative (`7d`) via the shared `epoch_ms` parser; providers always receive epoch-ms
- README quickstart: `list stats` orientation step + `--brief` recommendation. Version → 0.5.0

## Test plan

- [x] `just fc` green (692 passed, +21 new tests, coverage 90.2%)
- [x] Single-name create shape pinned byte-identical; batch order/partial-failure/flag-propagation covered; due-date normalization asserted at provider call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)