### PR TITLE
Reword ResourceAccessError; lock down --name-only filter (r9 follow-ups)

### DIFF
--- a/taskbench/core/client.py
+++ b/taskbench/core/client.py
@@ -74,12 +74,17 @@ class ClickUpClient:
                     error_data = {}
                 detail = error_data.get("err", "") if isinstance(error_data, dict) else ""
                 if self._RESOURCE_ENDPOINT_RE.search(endpoint):
+                    # Lead with the most-likely cause (resource missing/inaccessible).
+                    # ClickUp returns HTTP 401 for unknown resource IDs; the literal
+                    # "Team not authorized" detail primes agents to chase auth, so it
+                    # moves into a parenthetical that follows the human-shaped framing.
                     message = (
-                        f"ClickUp returned 401 for {endpoint}"
-                        f"{': ' + detail if detail else ''}. "
-                        "For resource endpoints this usually means the ID does not exist "
-                        "or is not accessible to this token; it can also mean the token "
-                        "itself is invalid — if other commands work, double-check the ID."
+                        f"Resource not found or not accessible: {endpoint}. "
+                        f"(ClickUp returns HTTP 401"
+                        f"{' — "' + detail + '"' if detail else ''} "
+                        "when an ID is missing, was deleted, or the token can't see it. "
+                        "If other commands work too, double-check the ID; "
+                        "if everything fails, the token itself may be invalid.)"
                     )
                     raise ResourceAccessError(message, response.status_code)
                 message = (

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -449,9 +449,11 @@ async def test_401_resource_endpoint_leads_with_id_interpretation(mock_clickup_c
     with pytest.raises(ResourceAccessError) as exc:
         await mock_clickup_client._request("GET", "/task/doesnotexist123")
     msg = str(exc.value)
-    assert msg.startswith("ClickUp returned 401 for /task/doesnotexist123")
-    assert "the ID does not exist" in msg
-    assert "token itself is invalid" in msg
+    # Lead with the most-likely cause so agents don't chase auth first.
+    assert msg.startswith("Resource not found or not accessible: /task/doesnotexist123")
+    assert msg.index("Resource not found") < msg.index("401")
+    assert "double-check the ID" in msg
+    assert "token itself may be invalid" in msg
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_task_commands.py
+++ b/tests/integration/test_task_commands.py
@@ -2368,3 +2368,49 @@ class TestCommentUserOptional:
         )
         assert comment.user is not None
         assert comment.user.username == "u"
+
+
+def test_name_only_substring_match_includes_eval_style_names() -> None:
+    """Lock down --name-only filtering against tricky names that contain the
+    query as a substring inside a hyphenated token (e.g. 'agent-test-eval-7').
+
+    The r9 eval reported one such task being excluded, which was almost
+    certainly cross-agent race (the sibling create/delete window), not a CLI
+    bug. This test pins the actual filter semantics so any regression
+    surfaces immediately.
+    """
+    from unittest.mock import AsyncMock, Mock, patch
+
+    mock_client = AsyncMock()
+    mock_client.get_user.return_value = Mock(id=1, username="evan", email="e@x.com")
+    mock_client.search_tasks.return_value = [
+        _make_task_b49("a", "agent-test-eval-7 update-flow"),
+        _make_task_b49("b", "Test Task — Minimal"),
+        _make_task_b49("c", "tEsTING the matcher"),
+        _make_task_b49("d", "Unrelated work"),
+        _make_task_b49("e", "contest entrant"),  # contains "test" as a substring
+    ]
+
+    def _ctx() -> AsyncMock:
+        m = AsyncMock()
+        m.__aenter__.return_value = mock_client
+        return m
+
+    with patch("taskbench.cli.commands.task.get_client") as mock_get_client:
+        mock_get_client.return_value = _ctx()
+        result = runner.invoke(
+            app,
+            ["task", "search", "--query", "test", "--workspace-id", "W1", "--name-only", "--brief"],
+        )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    names = [t["name"] for t in data["data"]]
+    # All four substring matches present (incl. the hyphenated/eval-style name and the case-insensitive one).
+    assert "agent-test-eval-7 update-flow" in names
+    assert "Test Task — Minimal" in names
+    assert "tEsTING the matcher" in names
+    assert "contest entrant" in names
+    # And only the obvious non-match was dropped.
+    assert "Unrelated work" not in names
+    assert data["count"] == 4

--- a/tests/unit/test_core_client.py
+++ b/tests/unit/test_core_client.py
@@ -345,9 +345,13 @@ async def test_401_on_resource_endpoint_raises_resource_access_error(mock_clicku
     with pytest.raises(ResourceAccessError) as exc:
         await mock_clickup_client._request("GET", "/task/doesnotexist123")
     msg = str(exc.value)
+    # Agent ergonomics (r9 follow-up): lead with the most-likely cause so the
+    # first thing a reader sees is "not found", not "401 Team not authorized".
+    assert msg.startswith("Resource not found or not accessible: /task/doesnotexist123")
+    assert msg.index("Resource not found") < msg.index("401")
+    # The literal API detail stays in the message, just demoted into the parenthetical.
     assert "Team not authorized" in msg
-    assert "401 for /task/doesnotexist123" in msg
-    assert "the ID does not exist" in msg
+    assert "double-check the ID" in msg
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes the two non-blocking items from eval r9.

**ResourceAccessError wording (the real fix)** — four consecutive evals flagged that the error body led with "ClickUp returned 401 ... Team not authorized" and primed agents to chase auth on what was actually a typo'd ID. PR #53 added the explanation sentence but it sat second. New shape:

> Resource not found or not accessible: /task/doesnotexist123. (ClickUp returns HTTP 401 — "Team not authorized" when an ID is missing, was deleted, or the token can't see it. If other commands work too, double-check the ID; if everything fails, the token itself may be invalid.)

The 401 detail and full API err text stay — they just move into the parenthetical so agents read the right interpretation first.

**\`--name-only\` lock-in (the defensive bit)** — r9 agent 8 reported a name-only filter missed an obvious substring match. Reading the code, the filter is a textbook case-insensitive substring (`query_lower in t.name.lower()`); the miss was almost certainly sibling-eval race (a parallel agent deleted the task between the two queries). New unit test exercises the path against tricky names (hyphen-embedded, case variants, edge cases like "contest" containing "test") so any regression surfaces immediately.

## Test plan

- [x] `just fc` green (746 passed, coverage 90.2%)
- [x] `FORCE_COLOR=1 pytest tests/integration` green (CI color condition)
- [x] Live smoke: `taskbench task get doesnotexist123` emits the new wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)