### PR TITLE
Add 'just audit' + CI security tier (issue #67 P3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,12 @@ jobs:
     - name: Run tests with coverage
       run: uv run pytest --cov=taskbench --cov-report=xml --cov-report=term-missing
 
+    - name: Audit dependencies for known vulnerabilities (issue #67 P3)
+      # Runs once per matrix entry; lightweight (a single PyPI lookup per dep).
+      # Failure here gates the merge — exactly the point of a security tier.
+      # `--path .venv` audits the project env, not pip-audit's tool env.
+      run: uv tool run pip-audit --strict --path .venv
+
     - name: Generate coverage badge
       if: matrix.python-version == '3.13' && github.ref == 'refs/heads/master'
       run: |

--- a/justfile
+++ b/justfile
@@ -28,6 +28,15 @@ check-local:
     @echo "Running live integration tests..."
     uv run pytest tests/live -v --no-cov
 
+# Audit dependencies for known vulnerabilities (issue #67 P3).
+# Runs pip-audit via `uv tool run` so it isn't a project dep — it's a
+# security tool, not a runtime requirement. `--path .venv` targets the
+# project environment, otherwise pip-audit ends up auditing its own
+# transitive deps in the isolated tool env.
+audit:
+    @echo "Auditing dependencies for known vulnerabilities..."
+    uv tool run pip-audit --strict --path .venv
+
 # Fix linting and formatting issues
 fix:
     @echo "Fixing linting issues..."

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12, <3.14"
 
 [options]
-exclude-newer = "2026-06-13T21:58:35.26991979Z"
+exclude-newer = "2026-06-14T00:19:58.052479582Z"
 exclude-newer-span = "P7D"
 
 [[package]]


### PR DESCRIPTION
Closes the P3 item in #67 — the missing security tier — and brings taskbench-planka up to CI parity.

**taskbench (this PR)**:
- New `just audit` recipe: `uv tool run pip-audit --strict --path .venv`. The `--path .venv` is load-bearing — without it, pip-audit audits its own tool env's deps (msgpack 1.2.0) which we can't control and which would block CI with false positives. With it, it audits our 39 packages and finds zero issues today.
- CI matrix runs the same audit after pytest, gates the merge.

**taskbench-planka (already pushed direct-to-master)**: First CI workflow on that repo — pytest matrix + audit on every push/PR. The smoke tests assert the planka entry point is discoverable by importlib.metadata, which protects against silent registration regressions.

## Test plan

- [x] `just fc` green (746 passed, coverage 90.2%)
- [x] `just audit` green locally (no known vulns)
- [x] taskbench-planka CI rehearsal green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)